### PR TITLE
chore: upgrade rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]


### PR DESCRIPTION
upgrade rust toolchain to 1.81.0