### PR TITLE
Implement BDN signature aggregation scheme

### DIFF
--- a/.config/rust-f3.dic
+++ b/.config/rust-f3.dic
@@ -42,3 +42,7 @@ G2
 JSON
 CBOR
 TODO
+coef_i
+sig_i
+pub_key_i
++

--- a/.config/rust-f3.dic
+++ b/.config/rust-f3.dic
@@ -1,4 +1,4 @@
-26
+23
 API/M
 APIs
 benchmark/GD
@@ -42,7 +42,4 @@ G2
 JSON
 CBOR
 TODO
-coef_i
-sig_i
-pub_key_i
 +

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2.19"
 parking_lot = "0.12"
 rand = "0.8"
+rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1", features = ["raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ ahash = "0.8"
 anyhow = "1"
 base32 = "0.5.1"
 base64 = "0.22"
-blake2 = { git = "https://github.com/huitseeker/hashes.git", branch = "blake2x-pr", features = ["blake2x"] }
+blake2 = { git = "https://github.com/huitseeker/hashes.git", rev = "4d3debf264a45da9e33d52645eb6ee9963336f66", features = ["blake2x"] } # PR: https://github.com/RustCrypto/hashes/pull/704
 bls-signatures = { version = "0.15" }
 bls12_381 = "0.8"
 cid = { version = "0.10.1", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ahash = "0.8"
 anyhow = "1"
 base32 = "0.5.1"
 base64 = "0.22"
+blake2 = { git = "https://github.com/huitseeker/hashes.git", branch = "blake2x-pr", features = ["blake2x"] }
 bls-signatures = { version = "0.15" }
 bls12_381 = "0.8"
 cid = { version = "0.10.1", features = ["std"] }

--- a/blssig/Cargo.toml
+++ b/blssig/Cargo.toml
@@ -20,4 +20,5 @@ rayon.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+hex.workspace = true
 rand.workspace = true

--- a/blssig/Cargo.toml
+++ b/blssig/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+blake2.workspace = true
 bls-signatures.workspace = true
 bls12_381.workspace = true
 filecoin-f3-gpbft = { path = "../gpbft", version = "0.1.0" }

--- a/blssig/Cargo.toml
+++ b/blssig/Cargo.toml
@@ -16,6 +16,7 @@ bls12_381.workspace = true
 filecoin-f3-gpbft = { path = "../gpbft", version = "0.1.0" }
 hashlink.workspace = true
 parking_lot.workspace = true
+rayon.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -2,16 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! BDN (Boneh-Drijvers-Neven) signature aggregation scheme, for preventing rogue public-key attacks.
+//! Those attacks could allow an attacker to forge a public-key and then make a verifiable
+//! signature for an aggregation of signatures. It fixes the situation by adding coefficients to the aggregate.
 //!
-//! NOTE: currently uses standard BLS aggregation without coefficient weighting, hence returns incorrect values compared to go-f3.
+//! See the papers:
+//! `https://eprint.iacr.org/2018/483.pdf`
+//! `https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html`
 //!
 use crate::verifier::BLSError;
-use bls_signatures::{PublicKey, Signature};
-use bls12_381::{G1Projective, G2Affine, G2Projective};
+use blake2::Blake2xs;
+use blake2::digest::{ExtendableOutput, Update, XofReader};
+use bls_signatures::{PublicKey, Serialize, Signature};
+use bls12_381::{G1Projective, G2Projective, Scalar};
 
 /// BDN aggregation context for managing signature and public key aggregation
 pub struct BDNAggregation {
-    pub_keys: Vec<PublicKey>,
+    pub(crate) pub_keys: Vec<PublicKey>,
+    pub(crate) coefficients: Vec<Scalar>,
+    pub(crate) terms: Vec<PublicKey>,
 }
 
 impl BDNAggregation {
@@ -20,11 +28,18 @@ impl BDNAggregation {
             return Err(BLSError::EmptyPublicKeys);
         }
 
-        Ok(Self { pub_keys })
+        let coefficients = Self::calc_coefficients(&pub_keys)?;
+        let terms = Self::calc_terms(&pub_keys, &coefficients);
+
+        Ok(Self {
+            pub_keys,
+            coefficients,
+            terms,
+        })
     }
 
-    /// Aggregates signatures using standard BLS aggregation
-    /// TODO: Implement BDN aggregation scheme: https://github.com/ChainSafe/rust-f3/issues/29
+    /// Aggregates signatures using BDN aggregation with coefficients.
+    /// Computes: sum((coef_i + 1) * sig_i)
     pub fn aggregate_sigs(&self, sigs: Vec<Signature>) -> Result<Signature, BLSError> {
         if sigs.len() != self.pub_keys.len() {
             return Err(BLSError::LengthMismatch {
@@ -33,11 +48,14 @@ impl BDNAggregation {
             });
         }
 
-        // Standard BLS aggregation
         let mut agg_point = G2Projective::identity();
-        for sig in sigs {
-            let sig: G2Affine = sig.into();
-            agg_point += sig;
+        for (i, sig) in sigs.iter().enumerate() {
+            let coef = self.coefficients[i];
+            let sig_point: G2Projective = (*sig).into();
+            let sig_c = sig_point * coef;
+            let sig_c = sig_c + sig_point;
+
+            agg_point += sig_c;
         }
 
         // Convert back to Signature
@@ -45,18 +63,68 @@ impl BDNAggregation {
         Ok(agg_sig)
     }
 
-    /// Aggregates public keys using standard BLS aggregation
-    /// TODO: Implement BDN aggregation scheme: https://github.com/ChainSafe/rust-f3/issues/29
-    pub fn aggregate_pub_keys(&self) -> Result<PublicKey, BLSError> {
-        // Standard BLS aggregation
+    /// Aggregates public keys indices using BDN aggregation with coefficients.
+    /// Computes: sum((coef_i + 1) * pub_key_i)
+    pub fn aggregate_pub_keys(&self, indices: &[u64]) -> Result<PublicKey, BLSError> {
+        // Sum of pre-computed terms (which are already (coef_i + 1) * pub_key_i)
         let mut agg_point = G1Projective::identity();
-        for pub_key in &self.pub_keys {
-            let pub_key_point: G1Projective = (*pub_key).into();
-            agg_point += pub_key_point;
+        for &idx in indices {
+            let idx = idx as usize;
+            if idx >= self.terms.len() {
+                return Err(BLSError::SignerIndexOutOfRange(idx));
+            }
+            let term_point: G1Projective = self.terms[idx].into();
+            agg_point += term_point;
         }
 
         // Convert back to PublicKey
         let agg_pub_key: PublicKey = agg_point.into();
         Ok(agg_pub_key)
+    }
+
+    pub fn calc_coefficients(pub_keys: &[PublicKey]) -> Result<Vec<Scalar>, BLSError> {
+        let mut hasher = Blake2xs::new(0xFFFF);
+
+        // Hash all public keys
+        for pub_key in pub_keys {
+            let bytes = pub_key.as_bytes();
+            hasher.update(&bytes);
+        }
+
+        // Read 16 bytes per public key
+        let mut reader = hasher.finalize_xof();
+        let mut output = vec![0u8; pub_keys.len() * 16];
+        reader.read(&mut output);
+
+        // Convert every consecutive 16 bytes chunk to a scalar
+        let mut coefficients = Vec::with_capacity(pub_keys.len());
+        for i in 0..pub_keys.len() {
+            let chunk = &output[i * 16..(i + 1) * 16];
+
+            // Convert 16 bytes to 32 bytes, for scalar (pad with zeros)
+            let mut bytes_32 = [0u8; 32];
+            bytes_32[..16].copy_from_slice(chunk);
+
+            // BLS12-381 scalars expects little-endian byte representation
+            let scalar = Scalar::from_bytes(&bytes_32);
+            if scalar.is_some().into() {
+                coefficients.push(scalar.unwrap());
+            } else {
+                return Err(BLSError::InvalidScalar);
+            }
+        }
+
+        Ok(coefficients)
+    }
+
+    pub fn calc_terms(pub_keys: &[PublicKey], coefficients: &[Scalar]) -> Vec<PublicKey> {
+        let mut terms = vec![];
+        for (i, pub_key) in pub_keys.iter().enumerate() {
+            let pub_key_point: G1Projective = (*pub_key).into();
+            let pub_c = pub_key_point * coefficients[i];
+            let term = pub_c + pub_key_point;
+            terms.push(term.into());
+        }
+        terms
     }
 }

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -81,7 +81,7 @@ impl BDNAggregation {
             }
         }
 
-        // Sum of pre-computed terms (which are already (coef_i + 1) * pub_key_i)
+        // Sum of pre-computed terms (which are already `(coef_i + 1) * pub_key_i`)
         let mut agg_point = G1Projective::identity();
         for &idx in indices {
             let term_point: G1Projective = self.terms[idx as usize].into();

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -72,7 +72,7 @@ impl BDNAggregation {
     }
 
     /// Aggregates public keys indices using BDN aggregation with coefficients.
-    /// Computes: sum((coef_i + 1) * pub_key_i)
+    /// Computes: `sum((coef_i + 1) * pub_key_i)`
     pub fn aggregate_pub_keys(&self, indices: &[u64]) -> Result<PublicKey, BLSError> {
         // Sum of pre-computed terms (which are already (coef_i + 1) * pub_key_i)
         let mut agg_point = G1Projective::identity();

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -117,12 +117,10 @@ impl BDNAggregation {
             bytes_32[..16].copy_from_slice(chunk);
 
             // BLS12-381 scalars expects little-endian byte representation
-            let scalar = Scalar::from_bytes(&bytes_32);
-            if scalar.is_some().into() {
-                coefficients.push(scalar.unwrap());
-            } else {
-                return Err(BLSError::InvalidScalar);
-            }
+            let scalar = Scalar::from_bytes(&bytes_32)
+                .into_option()
+                .ok_or(BLSError::InvalidScalar)?;
+            coefficients.push(scalar);
         }
 
         Ok(coefficients)

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -14,6 +14,7 @@ use blake2::Blake2xs;
 use blake2::digest::{ExtendableOutput, Update, XofReader};
 use bls_signatures::{PublicKey, Serialize, Signature};
 use bls12_381::{G1Projective, G2Projective, Scalar};
+use rayon::prelude::*;
 
 /// BDN aggregation context for managing signature and public key aggregation
 pub struct BDNAggregation {
@@ -118,13 +119,15 @@ impl BDNAggregation {
     }
 
     pub fn calc_terms(pub_keys: &[PublicKey], coefficients: &[Scalar]) -> Vec<PublicKey> {
-        let mut terms = vec![];
-        for (i, pub_key) in pub_keys.iter().enumerate() {
-            let pub_key_point: G1Projective = (*pub_key).into();
-            let pub_c = pub_key_point * coefficients[i];
-            let term = pub_c + pub_key_point;
-            terms.push(term.into());
-        }
-        terms
+        pub_keys
+            .par_iter()
+            .enumerate()
+            .map(|(i, pub_key)| {
+                let pub_key_point: G1Projective = (*pub_key).into();
+                let pub_c = pub_key_point * coefficients[i];
+                let term = pub_c + pub_key_point;
+                term.into()
+            })
+            .collect()
     }
 }

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -51,14 +51,15 @@ impl BDNAggregation {
             });
         }
 
+        for &idx in indices {
+            if idx as usize >= self.coefficients.len() {
+                return Err(BLSError::SignerIndexOutOfRange(idx as usize));
+            }
+        }
+
         let mut agg_point = G2Projective::identity();
         for (sig, &idx) in sigs.iter().zip(indices.iter()) {
-            let idx = idx as usize;
-            if idx >= self.coefficients.len() {
-                return Err(BLSError::SignerIndexOutOfRange(idx));
-            }
-
-            let coef = self.coefficients[idx];
+            let coef = self.coefficients[idx as usize];
             let sig_point: G2Projective = (*sig).into();
             let sig_c = sig_point * coef;
             let sig_c = sig_c + sig_point;
@@ -74,14 +75,16 @@ impl BDNAggregation {
     /// Aggregates public keys indices using BDN aggregation with coefficients.
     /// Computes: `sum((coef_i + 1) * pub_key_i)`
     pub fn aggregate_pub_keys(&self, indices: &[u64]) -> Result<PublicKey, BLSError> {
+        for &idx in indices {
+            if idx as usize >= self.terms.len() {
+                return Err(BLSError::SignerIndexOutOfRange(idx as usize));
+            }
+        }
+
         // Sum of pre-computed terms (which are already (coef_i + 1) * pub_key_i)
         let mut agg_point = G1Projective::identity();
         for &idx in indices {
-            let idx = idx as usize;
-            if idx >= self.terms.len() {
-                return Err(BLSError::SignerIndexOutOfRange(idx));
-            }
-            let term_point: G1Projective = self.terms[idx].into();
+            let term_point: G1Projective = self.terms[idx as usize].into();
             agg_point += term_point;
         }
 

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -18,7 +18,6 @@ use rayon::prelude::*;
 
 /// BDN aggregation context for managing signature and public key aggregation
 pub struct BDNAggregation {
-    pub(crate) pub_keys: Vec<PublicKey>,
     pub(crate) coefficients: Vec<Scalar>,
     pub(crate) terms: Vec<PublicKey>,
 }
@@ -33,25 +32,33 @@ impl BDNAggregation {
         let terms = Self::calc_terms(&pub_keys, &coefficients);
 
         Ok(Self {
-            pub_keys,
             coefficients,
             terms,
         })
     }
 
     /// Aggregates signatures using BDN aggregation with coefficients.
-    /// Computes: sum((coef_i + 1) * sig_i)
-    pub fn aggregate_sigs(&self, sigs: Vec<Signature>) -> Result<Signature, BLSError> {
-        if sigs.len() != self.pub_keys.len() {
+    /// Computes: sum((coef_i + 1) * sig_i) for signatures at the given indices
+    pub fn aggregate_sigs(
+        &self,
+        indices: &[u64],
+        sigs: &[Signature],
+    ) -> Result<Signature, BLSError> {
+        if sigs.len() != indices.len() {
             return Err(BLSError::LengthMismatch {
-                pub_keys: self.pub_keys.len(),
+                pub_keys: indices.len(),
                 sigs: sigs.len(),
             });
         }
 
         let mut agg_point = G2Projective::identity();
-        for (i, sig) in sigs.iter().enumerate() {
-            let coef = self.coefficients[i];
+        for (sig, &idx) in sigs.iter().zip(indices.iter()) {
+            let idx = idx as usize;
+            if idx >= self.coefficients.len() {
+                return Err(BLSError::SignerIndexOutOfRange(idx));
+            }
+
+            let coef = self.coefficients[idx];
             let sig_point: G2Projective = (*sig).into();
             let sig_c = sig_point * coef;
             let sig_c = sig_c + sig_point;

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -38,7 +38,7 @@ impl BDNAggregation {
     }
 
     /// Aggregates signatures using BDN aggregation with coefficients.
-    /// Computes: sum((coef_i + 1) * sig_i) for signatures at the given indices
+    /// Computes: `sum((coef_i + 1) * sig_i)` for signatures at the given indices
     pub fn aggregate_sigs(
         &self,
         indices: &[u64],

--- a/blssig/src/bdn/mod.rs
+++ b/blssig/src/bdn/mod.rs
@@ -6,8 +6,8 @@
 //! signature for an aggregation of signatures. It fixes the situation by adding coefficients to the aggregate.
 //!
 //! See the papers:
-//! `https://eprint.iacr.org/2018/483.pdf`
-//! `https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html`
+//! - <https://eprint.iacr.org/2018/483.pdf>
+//! - <https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html>
 //!
 use crate::verifier::BLSError;
 use blake2::Blake2xs;

--- a/blssig/src/lib.rs
+++ b/blssig/src/lib.rs
@@ -8,7 +8,10 @@
 //! The BDN (Boneh-Drijvers-Neven) scheme is used for signature and public key aggregation
 //! to prevent rogue public-key attacks.
 
+pub use verifier::{BLSError, BLSVerifier};
+
 mod bdn;
 mod verifier;
 
-pub use verifier::{BLSError, BLSVerifier};
+#[cfg(test)]
+mod tests;

--- a/blssig/src/tests.rs
+++ b/blssig/src/tests.rs
@@ -1,0 +1,226 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Tests for BDN (Boneh-Drijvers-Neven) signature aggregation.
+//!
+//! ## Tested scenarios
+//!
+//! ### Correctness
+//! - [`test_bdn_aggregate_and_verify`]: aggregate of N distinct signers verifies correctly.
+//!- [`test_bdn_mismatched_key_order_fails`]: BDN coefficients depend on the full ordered key
+//!   list; re-ordering keys produces a different aggregate that does not verify under the
+//!   original order.
+//! - [`test_bdn_wrong_signer_indices_fails`]: verifying with a different signer set than was
+//!   used to produce the aggregate must fail.
+//! - [`test_bdn_corrupted_agg_sig_fails`]: a bit-flipped aggregate signature is rejected.
+//! - [`test_bdn_wrong_message_fails`]: verification against a different message is rejected.
+//!
+//! ### Input validation
+//! - [`test_bdn_empty_pub_keys_fails`]: `BDNAggregation::new`: an empty key list.
+//! - [`test_bdn_aggregate_sigs_length_mismatch_fails`]: mismatched indices / signatures lengths.
+//! - [`test_bdn_aggregate_sigs_out_of_range_fails`]: index >= power-table size.
+//! - [`test_bdn_aggregate_pub_keys_out_of_range_fails`]: same for `aggregate_pub_keys`.
+//! - [`test_verifier_aggregate_empty_pub_keys_fails`]: `Verifier::aggregate` rejects empty keys.
+//! - [`test_verifier_aggregate_length_mismatch_fails`]: mismatched public keys / signatures.
+
+use crate::bdn::BDNAggregation;
+use crate::verifier::{BLSError, BLSVerifier};
+use bls_signatures::{PrivateKey, Serialize};
+use filecoin_f3_gpbft::api::Verifier;
+use filecoin_f3_gpbft::PubKey;
+
+#[test]
+fn test_bdn_aggregate_and_verify() {
+    let verifier = BLSVerifier::new();
+    let msg = b"test bdn distinct keys";
+
+    let keys: Vec<PrivateKey> = (0..3).map(|_| random_key()).collect();
+    let pub_keys: Vec<PubKey> = keys.iter().map(|k| pub_key_bytes(k)).collect();
+    let sigs: Vec<Vec<u8>> = keys.iter().map(|k| sign_bytes(k, msg)).collect();
+
+    let agg_sig = verifier
+        .aggregate(&pub_keys, &sigs)
+        .expect("aggregation should succeed");
+    verifier
+        .verify_aggregate(msg, &agg_sig, &pub_keys, &[0, 1, 2])
+        .expect("verification should succeed");
+}
+
+#[test]
+fn test_bdn_mismatched_key_order_fails() {
+    let verifier = BLSVerifier::new();
+    let msg = b"test bdn key order";
+
+    let key1 = random_key();
+    let key2 = random_key();
+
+    let pub_keys_ab = vec![pub_key_bytes(&key1), pub_key_bytes(&key2)];
+    let pub_keys_ba = vec![pub_key_bytes(&key2), pub_key_bytes(&key1)];
+
+    // Aggregate with order [A, B]: A is index 0, B is index 1
+    let sigs_ab = vec![sign_bytes(&key1, msg), sign_bytes(&key2, msg)];
+    let agg_ab = verifier
+        .aggregate(&pub_keys_ab, &sigs_ab)
+        .expect("aggregation should succeed");
+
+    // Aggregate with order [B, A]: B is index 0, A is index 1
+    let sigs_ba = vec![sign_bytes(&key2, msg), sign_bytes(&key1, msg)];
+    let agg_ba = verifier
+        .aggregate(&pub_keys_ba, &sigs_ba)
+        .expect("aggregation should succeed");
+
+    // Different orderings must produce different aggregates
+    assert_ne!(
+        agg_ab, agg_ba,
+        "different key orderings must produce different aggregates"
+    );
+
+    // agg_ab must not verify under the [B, A] power table
+    let result = verifier.verify_aggregate(msg, &agg_ab, &pub_keys_ba, &[0, 1]);
+    assert!(
+        result.is_err(),
+        "aggregate from [A,B] order must not verify under [B,A] order"
+    );
+}
+
+#[test]
+fn test_bdn_wrong_signer_indices_fails() {
+    let verifier = BLSVerifier::new();
+    let msg = b"test bdn wrong indices";
+
+    let keys: Vec<PrivateKey> = (0..3).map(|_| random_key()).collect();
+    let power_table: Vec<PubKey> = keys.iter().map(|k| pub_key_bytes(k)).collect();
+
+    // Keys 0 and 1 sign
+    let signer_indices = [0u64, 1];
+    let typed_pub_keys: Vec<_> = power_table
+        .iter()
+        .map(|pk| bls_signatures::PublicKey::from_bytes(&pk.0).unwrap())
+        .collect();
+    let typed_sigs: Vec<bls_signatures::Signature> = signer_indices
+        .iter()
+        .map(|&i| keys[i as usize].sign(msg))
+        .collect();
+
+    let bdn = BDNAggregation::new(typed_pub_keys).expect("BDN creation should succeed");
+    let agg_sig = bdn
+        .aggregate_sigs(&signer_indices, &typed_sigs)
+        .expect("aggregation should succeed");
+
+    // Claim indices [0, 2] instead of the actual [0, 1]
+    let result = verifier.verify_aggregate(msg, &agg_sig.as_bytes(), &power_table, &[0, 2]);
+    assert!(
+        result.is_err(),
+        "verification with wrong signer indices must fail"
+    );
+}
+
+#[test]
+fn test_bdn_corrupted_agg_sig_fails() {
+    let verifier = BLSVerifier::new();
+    let msg = b"test bdn corruption";
+
+    let key1 = random_key();
+    let key2 = random_key();
+    let pub_keys = vec![pub_key_bytes(&key1), pub_key_bytes(&key2)];
+    let sigs = vec![sign_bytes(&key1, msg), sign_bytes(&key2, msg)];
+
+    let mut agg_sig = verifier
+        .aggregate(&pub_keys, &sigs)
+        .expect("aggregation should succeed");
+    agg_sig[0] ^= 0xff;
+
+    let result = verifier.verify_aggregate(msg, &agg_sig, &pub_keys, &[0, 1]);
+    assert!(result.is_err(), "corrupted aggregate signature must be rejected");
+}
+
+#[test]
+fn test_bdn_wrong_message_fails() {
+    let verifier = BLSVerifier::new();
+    let msg = b"correct message";
+
+    let key1 = random_key();
+    let key2 = random_key();
+    let pub_keys = vec![pub_key_bytes(&key1), pub_key_bytes(&key2)];
+    let sigs = vec![sign_bytes(&key1, msg), sign_bytes(&key2, msg)];
+
+    let agg_sig = verifier
+        .aggregate(&pub_keys, &sigs)
+        .expect("aggregation should succeed");
+
+    let result = verifier.verify_aggregate(b"wrong message", &agg_sig, &pub_keys, &[0, 1]);
+    assert!(result.is_err(), "verification against wrong message must fail");
+}
+
+// -- Input validation ---------------------------------------------------------
+
+#[test]
+fn test_bdn_empty_pub_keys_fails() {
+    let result = BDNAggregation::new(vec![]);
+    assert!(matches!(result, Err(BLSError::EmptyPublicKeys)));
+}
+
+#[test]
+fn test_bdn_aggregate_sigs_length_mismatch_fails() {
+    let key = random_key();
+    let typed_pub_key =
+        bls_signatures::PublicKey::from_bytes(&pub_key_bytes(&key).0).unwrap();
+    let bdn = BDNAggregation::new(vec![typed_pub_key]).expect("BDN creation should succeed");
+
+    let sig = key.sign(b"msg");
+    let result = bdn.aggregate_sigs(&[0, 1], &[sig]);
+    assert!(matches!(result, Err(BLSError::LengthMismatch { .. })));
+}
+
+#[test]
+fn test_bdn_aggregate_sigs_out_of_range_fails() {
+    let key = random_key();
+    let typed_pub_key =
+        bls_signatures::PublicKey::from_bytes(&pub_key_bytes(&key).0).unwrap();
+    let bdn = BDNAggregation::new(vec![typed_pub_key]).expect("BDN creation should succeed");
+
+    let sig = key.sign(b"msg");
+    let result = bdn.aggregate_sigs(&[5], &[sig]);
+    assert!(matches!(result, Err(BLSError::SignerIndexOutOfRange(5))));
+}
+
+#[test]
+fn test_bdn_aggregate_pub_keys_out_of_range_fails() {
+    let key = random_key();
+    let typed_pub_key =
+        bls_signatures::PublicKey::from_bytes(&pub_key_bytes(&key).0).unwrap();
+    let bdn = BDNAggregation::new(vec![typed_pub_key]).expect("BDN creation should succeed");
+
+    let result = bdn.aggregate_pub_keys(&[5]);
+    assert!(matches!(result, Err(BLSError::SignerIndexOutOfRange(5))));
+}
+
+#[test]
+fn test_verifier_aggregate_empty_pub_keys_fails() {
+    let verifier = BLSVerifier::new();
+    let result = verifier.aggregate(&[], &[]);
+    assert!(matches!(result, Err(BLSError::EmptyPublicKeys)));
+}
+
+#[test]
+fn test_verifier_aggregate_length_mismatch_fails() {
+    let verifier = BLSVerifier::new();
+    let key = random_key();
+    let pk = pub_key_bytes(&key);
+    let sig = sign_bytes(&key, b"msg");
+
+    let result = verifier.aggregate(&[pk.clone(), pk], &[sig]);
+    assert!(matches!(result, Err(BLSError::LengthMismatch { .. })));
+}
+
+fn random_key() -> PrivateKey {
+    PrivateKey::generate(&mut rand::thread_rng())
+}
+
+fn pub_key_bytes(key: &PrivateKey) -> PubKey {
+    PubKey(key.public_key().as_bytes().to_vec())
+}
+
+fn sign_bytes(key: &PrivateKey, msg: &[u8]) -> Vec<u8> {
+    key.sign(msg).as_bytes().to_vec()
+}

--- a/blssig/src/verifier/mod.rs
+++ b/blssig/src/verifier/mod.rs
@@ -51,7 +51,7 @@ pub struct BLSVerifier {
     point_cache: RwLock<LruCache<Vec<u8>, PublicKey>>,
     /// Cache for current power table's BDN aggregation
     /// Only caches the current since power tables don't tend to repeat after rotation
-    bdn_cache: RwLock<Option<(Vec<PubKey>, Arc<BDNAggregation>)>>,
+    current_bdn_cache: RwLock<Option<(Vec<PubKey>, Arc<BDNAggregation>)>>,
 }
 
 impl Default for BLSVerifier {
@@ -74,7 +74,7 @@ impl BLSVerifier {
         Self {
             // key size: 48, value size: 196, total estimated: 1.83 MiB
             point_cache: RwLock::new(LruCache::new(MAX_POINT_CACHE_SIZE)),
-            bdn_cache: RwLock::new(None),
+            current_bdn_cache: RwLock::new(None),
         }
     }
 
@@ -129,7 +129,7 @@ impl BLSVerifier {
     /// Gets a cached BDN aggregation or creates and caches it
     fn get_or_cache_bdn(&self, power_table: &[PubKey]) -> Result<Arc<BDNAggregation>, BLSError> {
         // Check cache first
-        if let Some((cached_power_table, cached_bdn)) = self.bdn_cache.read().as_ref() {
+        if let Some((cached_power_table, cached_bdn)) = self.current_bdn_cache.read().as_ref() {
             if cached_power_table == power_table {
                 return Ok(cached_bdn.clone());
             }
@@ -147,7 +147,7 @@ impl BLSVerifier {
         let bdn = Arc::new(BDNAggregation::new(typed_pub_keys)?);
 
         // Cache it
-        self.bdn_cache
+        self.current_bdn_cache
             .write()
             .replace((power_table.to_vec(), bdn.clone()));
 

--- a/blssig/src/verifier/mod.rs
+++ b/blssig/src/verifier/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::sync::Arc;
 use bls_signatures::{PublicKey, Serialize, Signature, verify_messages};
 use filecoin_f3_gpbft::PubKey;
 use filecoin_f3_gpbft::api::Verifier;
@@ -43,11 +44,14 @@ pub enum BLSError {
 ///
 /// This verifier implements the same scheme used by `go-f3/blssig`, with:
 /// - BLS12_381 curve
-/// - G1 for public keys, G2 for signatures  
+/// - G1 for public keys, G2 for signatures
 /// - BDN aggregation for rogue-key attack prevention
 pub struct BLSVerifier {
     /// Cache for deserialized public key points to avoid expensive repeated operations
     point_cache: RwLock<LruCache<Vec<u8>, PublicKey>>,
+    /// Cache for current power table's BDN aggregation
+    /// Only caches the current since power tables don't tend to repeat after rotation
+    bdn_cache: RwLock<Option<(Vec<PubKey>, Arc<BDNAggregation>)>>,
 }
 
 impl Default for BLSVerifier {
@@ -70,6 +74,7 @@ impl BLSVerifier {
         Self {
             // key size: 48, value size: 196, total estimated: 1.83 MiB
             point_cache: RwLock::new(LruCache::new(MAX_POINT_CACHE_SIZE)),
+            bdn_cache: RwLock::new(None),
         }
     }
 
@@ -119,6 +124,34 @@ impl BLSVerifier {
 
     fn deserialize_signature(&self, sig: &[u8]) -> Result<Signature, BLSError> {
         Signature::from_bytes(sig).map_err(BLSError::SignatureDeserialization)
+    }
+
+    /// Gets a cached BDN aggregation or creates and caches it
+    fn get_or_cache_bdn(&self, power_table: &[PubKey]) -> Result<Arc<BDNAggregation>, BLSError> {
+        // Check cache first
+        if let Some((cached_power_table, cached_bdn)) = self.bdn_cache.read().as_ref() {
+            if cached_power_table == power_table {
+                return Ok(cached_bdn.clone());
+            }
+        }
+
+        // Deserialize and create new BDN aggregation
+        let mut typed_pub_keys = vec![];
+        for pub_key in power_table {
+            if pub_key.0.len() != BLS_PUBLIC_KEY_LENGTH {
+                return Err(BLSError::InvalidPublicKeyLength(pub_key.0.len()));
+            }
+            typed_pub_keys.push(self.get_or_cache_public_key(&pub_key.0)?);
+        }
+
+        let bdn = Arc::new(BDNAggregation::new(typed_pub_keys)?);
+
+        // Cache it
+        self.bdn_cache
+            .write()
+            .replace((power_table.to_vec(), bdn.clone()));
+
+        Ok(bdn)
     }
 }
 
@@ -178,16 +211,7 @@ impl Verifier for BLSVerifier {
             return Err(BLSError::EmptySigners);
         }
 
-        let mut typed_pub_keys = vec![];
-        for pub_key in power_table {
-            if pub_key.0.len() != BLS_PUBLIC_KEY_LENGTH {
-                return Err(BLSError::InvalidPublicKeyLength(pub_key.0.len()));
-            }
-
-            typed_pub_keys.push(self.get_or_cache_public_key(&pub_key.0)?);
-        }
-
-        let bdn = BDNAggregation::new(typed_pub_keys)?;
+        let bdn = self.get_or_cache_bdn(power_table)?;
         let agg_pub_key = bdn.aggregate_pub_keys(signer_indices)?;
         let agg_pub_key_bytes = PubKey(agg_pub_key.as_bytes().to_vec());
         self.verify_single(&agg_pub_key_bytes, payload, agg_sig)

--- a/blssig/src/verifier/mod.rs
+++ b/blssig/src/verifier/mod.rs
@@ -193,7 +193,8 @@ impl Verifier for BLSVerifier {
         }
 
         let bdn = BDNAggregation::new(typed_pub_keys)?;
-        let agg_sig = bdn.aggregate_sigs(typed_sigs)?;
+        let indices: Vec<u64> = (0..typed_sigs.len() as u64).collect();
+        let agg_sig = bdn.aggregate_sigs(&indices, &typed_sigs)?;
         Ok(agg_sig.as_bytes())
     }
 

--- a/blssig/src/verifier/mod.rs
+++ b/blssig/src/verifier/mod.rs
@@ -17,6 +17,8 @@ mod tests;
 pub enum BLSError {
     #[error("empty public keys provided")]
     EmptyPublicKeys,
+    #[error("empty signers provided")]
+    EmptySigners,
     #[error("empty signatures provided")]
     EmptySignatures,
     #[error("invalid public key length: expected {BLS_PUBLIC_KEY_LENGTH} bytes, got {0}")]
@@ -31,6 +33,10 @@ pub enum BLSError {
     SignatureVerificationFailed,
     #[error("mismatched number of public keys and signatures: {pub_keys} != {sigs}")]
     LengthMismatch { pub_keys: usize, sigs: usize },
+    #[error("invalid scalar value")]
+    InvalidScalar,
+    #[error("signer index {0} is out of range")]
+    SignerIndexOutOfRange(usize),
 }
 
 /// BLS signature verifier using BDN aggregation scheme
@@ -162,14 +168,18 @@ impl Verifier for BLSVerifier {
         &self,
         payload: &[u8],
         agg_sig: &[u8],
-        signers: &[PubKey],
+        power_table: &[PubKey],
+        signer_indices: &[u64],
     ) -> Result<(), Self::Error> {
-        if signers.is_empty() {
+        if power_table.is_empty() {
             return Err(BLSError::EmptyPublicKeys);
+        }
+        if signer_indices.is_empty() {
+            return Err(BLSError::EmptySigners);
         }
 
         let mut typed_pub_keys = vec![];
-        for pub_key in signers {
+        for pub_key in power_table {
             if pub_key.0.len() != BLS_PUBLIC_KEY_LENGTH {
                 return Err(BLSError::InvalidPublicKeyLength(pub_key.0.len()));
             }
@@ -178,7 +188,7 @@ impl Verifier for BLSVerifier {
         }
 
         let bdn = BDNAggregation::new(typed_pub_keys)?;
-        let agg_pub_key = bdn.aggregate_pub_keys()?;
+        let agg_pub_key = bdn.aggregate_pub_keys(signer_indices)?;
         let agg_pub_key_bytes = PubKey(agg_pub_key.as_bytes().to_vec());
         self.verify_single(&agg_pub_key_bytes, payload, agg_sig)
     }

--- a/blssig/src/verifier/mod.rs
+++ b/blssig/src/verifier/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::sync::Arc;
 use bls_signatures::{PublicKey, Serialize, Signature, verify_messages};
 use filecoin_f3_gpbft::PubKey;
 use filecoin_f3_gpbft::api::Verifier;
 use hashlink::LruCache;
 use parking_lot::RwLock;
+use std::sync::Arc;
 use thiserror::Error;
 
 use crate::bdn::BDNAggregation;

--- a/blssig/src/verifier/tests.rs
+++ b/blssig/src/verifier/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::BLSVerifier;
+use crate::bdn::BDNAggregation;
 use bls_signatures::{PrivateKey, Serialize};
 use filecoin_f3_gpbft::PubKey;
 use filecoin_f3_gpbft::api::Verifier;
@@ -66,5 +67,51 @@ fn test_invalid_signature() {
     assert!(
         result.is_err(),
         "corrupted signature should fail verification"
+    );
+}
+
+#[test]
+fn test_aggregate_signature_verification() {
+    let verifier = BLSVerifier::new();
+    let message = b"consensus message";
+
+    // Generate 10 validators for the power table
+    let mut signers = Vec::new();
+    let mut power_table = Vec::new();
+    for _ in 0..10 {
+        let private_key = PrivateKey::generate(&mut rand::thread_rng());
+        let signer = BLSSigner::new(private_key);
+        power_table.push(signer.public_key().clone());
+        signers.push(signer);
+    }
+
+    // Only 5 validators sign (indices 0, 2, 4, 6, 8)
+    let signers_subset = vec![0u64, 2, 4, 6, 8];
+    let sigs: Vec<Vec<u8>> = signers_subset
+        .iter()
+        .map(|&i| signers[i as usize].sign(message))
+        .collect();
+
+    // Aggregate using BDN with full power table
+    let typed_pub_keys: Vec<_> = power_table
+        .iter()
+        .map(|pk| bls_signatures::PublicKey::from_bytes(&pk.0).unwrap())
+        .collect();
+    let typed_sigs: Vec<_> = sigs
+        .iter()
+        .map(|sig| bls_signatures::Signature::from_bytes(sig).unwrap())
+        .collect();
+
+    let bdn = BDNAggregation::new(typed_pub_keys).expect("BDN creation should succeed");
+    let agg_sig = bdn
+        .aggregate_sigs(&signers_subset, &typed_sigs)
+        .expect("aggregation should succeed");
+
+    // Verify aggregate using full power table and signer indices
+    let result =
+        verifier.verify_aggregate(message, &agg_sig.as_bytes(), &power_table, &signers_subset);
+    assert!(
+        result.is_ok(),
+        "aggregate signature verification should succeed"
     );
 }

--- a/certs/src/lib.rs
+++ b/certs/src/lib.rs
@@ -293,27 +293,19 @@ fn verify_signature(
     // Encode the payload for signing
     let payload_bytes = payload.serialize_for_signing(&network.to_string());
 
-    // Extract public keys for signers
-    let signers_pk: Vec<PubKey> = signers
+    // Extract all public keys from power table
+    let pub_keys: Vec<PubKey> = power_table
         .iter()
-        .map(|&index| power_table[index as usize].pub_key.clone())
+        .map(|entry| entry.pub_key.clone())
         .collect();
 
     // Verify the aggregate signature
-    let res = verifier
-        .verify_aggregate(&payload_bytes, &cert.signature, &signers_pk)
+    verifier
+        .verify_aggregate(&payload_bytes, &cert.signature, &pub_keys, &signers)
         .map_err(|e| CertsError::SignatureVerificationFailed {
             instance: cert.gpbft_instance,
             error: e.to_string(),
-        });
-
-    // Temporarily silencing verification errors
-    // The current BDN implementation uses standard BLS aggregation, causing verification to fail.
-    // This logging allows development to continue.
-    // TODO: Remove this workaround once BDN aggregation scheme is implemented
-    if let Err(err) = res {
-        println!("WARN: {}", err);
-    }
+        })?;
 
     Ok(())
 }
@@ -721,7 +713,8 @@ mod tests {
             &self,
             payload: &[u8],
             agg_sig: &[u8],
-            signers: &[PubKey],
+            power_table: &[PubKey],
+            signer_indices: &[u64],
         ) -> std::result::Result<(), Self::Error> {
             Ok(())
         }

--- a/gpbft/src/api.rs
+++ b/gpbft/src/api.rs
@@ -33,12 +33,16 @@ pub trait Verifier: Send + Sync {
 
     /// Verifies an aggregate signature
     ///
+    /// The aggregation requires all public keys from the power table in order
+    /// to compute coefficients correctly, even when only a subset actually signed.
+    ///
     /// This method must be safe for concurrent use.
     ///
     /// # Arguments
     /// * `payload` - The payload that was signed
     /// * `agg_sig` - The aggregate signature to verify
-    /// * `signers` - The public keys of the signers
+    /// * `power_table` - All public keys from the power table
+    /// * `signer_indices` - Indices of the signers in the power table
     ///
     /// # Returns
     /// A Result indicating success or failure with an error message
@@ -46,6 +50,7 @@ pub trait Verifier: Send + Sync {
         &self,
         payload: &[u8],
         agg_sig: &[u8],
-        signers: &[PubKey],
+        power_table: &[PubKey],
+        signer_indices: &[u64],
     ) -> Result<(), Self::Error>;
 }

--- a/lightclient/Cargo.toml
+++ b/lightclient/Cargo.toml
@@ -17,4 +17,5 @@ anyhow.workspace = true
 base64 = { workspace = true }
 hex.workspace = true
 keccak-hash.workspace = true
+serde_json.workspace = true
 tokio.workspace = true

--- a/lightclient/examples/certificates_validation.rs
+++ b/lightclient/examples/certificates_validation.rs
@@ -17,24 +17,8 @@
 use anyhow::Result;
 use filecoin_f3_gpbft::PowerEntries;
 use filecoin_f3_gpbft::powertable::{is_strong_quorum, signer_scaled_total};
-use filecoin_f3_lightclient::LightClient;
+use filecoin_f3_lightclient::{LightClient, NETWORK_CONFIGS, NetworkConfig};
 use std::env;
-
-struct NetworkConfig {
-    network_name: &'static str,
-    endpoint: &'static str,
-}
-
-const NETWORK_CONFIGS: [NetworkConfig; 2] = [
-    NetworkConfig {
-        network_name: "calibrationnet",
-        endpoint: "https://filecoin-calibration.ipc.space/rpc/v1",
-    },
-    NetworkConfig {
-        network_name: "filecoin",
-        endpoint: "https://filecoin.ipc.space/rpc/v1",
-    },
-];
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/lightclient/src/bin/fetch_fixtures.rs
+++ b/lightclient/src/bin/fetch_fixtures.rs
@@ -1,0 +1,54 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Fetches F3 finality certificates from the Filecoin mainnet RPC and writes
+//! them to `tests/fixtures/filecoin_certs.json` as a JSON array in the raw RPC
+//! format.
+//!
+//! Run once to regenerate fixtures:
+//! ```bash
+//! cargo run --bin fetch_fixtures -- [num_certs]
+//! ```
+//! Defaults to fetching 10 certificates (instances 0..9).
+
+use anyhow::Result;
+use filecoin_f3_lightclient::NETWORK_CONFIGS;
+use filecoin_f3_rpc::RPCClient;
+use std::env;
+use std::path::PathBuf;
+
+const FILECOIN_NETWORK_NAME: &str = "filecoin";
+const DEFAULT_NUM_CERTS: u64 = 10;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let num_certs: u64 = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_NUM_CERTS);
+
+    let config = NETWORK_CONFIGS
+        .iter()
+        .find(|c| c.network_name == FILECOIN_NETWORK_NAME).unwrap();
+
+    println!("Fetching {} certificates from {}", num_certs, config.endpoint);
+
+    let client = RPCClient::new(config.endpoint)?;
+    let mut certs = Vec::with_capacity(num_certs as usize);
+
+    for i in 0..num_certs {
+        println!("  fetching instance {}...", i);
+        let cert = client.get_certificate(i).await?;
+        println!(" ok (signers: {}, deltas: {})", cert.signers.len(), cert.power_table_delta.len());
+        certs.push(cert);
+    }
+
+    let out_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/filecoin_certs.json");
+
+    let json = serde_json::to_string_pretty(&certs)?;
+    std::fs::write(&out_path, &json)?;
+    println!("Written {} certificates to {}", certs.len(), out_path.display());
+
+    Ok(())
+}

--- a/lightclient/src/lib.rs
+++ b/lightclient/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-mod rpc_to_internal;
+pub mod rpc_to_internal;
 
 extern crate core;
 
@@ -11,6 +11,22 @@ use filecoin_f3_certs as certs;
 use filecoin_f3_certs::validate_finality_certificates;
 use filecoin_f3_gpbft::{ECChain, NetworkName, PowerEntries};
 use filecoin_f3_rpc::RPCClient;
+
+pub struct NetworkConfig {
+    pub network_name: &'static str,
+    pub endpoint: &'static str,
+}
+
+pub const NETWORK_CONFIGS: [NetworkConfig; 2] = [
+    NetworkConfig {
+        network_name: "calibrationnet",
+        endpoint: "https://rpc.ankr.com/filecoin_testnet",
+    },
+    NetworkConfig {
+        network_name: "filecoin",
+        endpoint: "https://api.node.glif.io/rpc/v1",
+    },
+];
 
 pub struct LightClient {
     rpc: RPCClient,

--- a/lightclient/tests/filecoin_mainnet.rs
+++ b/lightclient/tests/filecoin_mainnet.rs
@@ -1,0 +1,186 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Integration tests for F3 certificate validation against real Filecoin mainnet data.
+//!
+//! Uses static fixtures fetched from the mainnet RPC (see `src/bin/fetch_fixtures.rs`).
+//! No network access is required to run these tests.
+
+use filecoin_f3_blssig::BLSVerifier;
+use filecoin_f3_certs::{CertsError, PowerTableDelta, validate_finality_certificates};
+use filecoin_f3_gpbft::{NetworkName, PowerEntries, PubKey, StoragePower};
+use filecoin_f3_lightclient::rpc_to_internal;
+use filecoin_f3_rpc as rpc;
+
+/// Validates 10 consecutive mainnet certificates starting from instance 0, using the
+/// real initial power table and a real BLS verifier. This exercises the full pipeline:
+/// BLS aggregate signature verification, power table diff application, and CID matching.
+#[test]
+fn test_validate_filecoin_mainnet_certificates() {
+    let power_table = load_initial_power_table();
+    let certs = load_certificates();
+
+    assert!(!certs.is_empty(), "no certificates loaded");
+
+    let num_certs = certs.len() as u64;
+    let last_cert = certs.last().unwrap();
+    let expected_final_power_table_cid = last_cert.supplemental_data.power_table;
+
+    let (final_instance, _chain, final_power_table) = validate_finality_certificates(
+        &BLSVerifier::new(),
+        NetworkName::Mainnet,
+        power_table,
+        0,
+        None,
+        &certs,
+    )
+    .expect("certificate validation failed");
+
+    assert_eq!(final_instance, num_certs);
+
+    // The final power table CID must match what the last certificate committed to
+    let final_power_table_cid = filecoin_f3_gpbft::cid_from_bytes(&final_power_table.serialize_cbor());
+    assert_eq!(
+        final_power_table_cid, expected_final_power_table_cid,
+        "final power table CID does not match last certificate's supplemental data"
+    );
+}
+
+/// Flipping bits in the aggregate BLS signature must fail with a signature error.
+/// This proves the verifier actually runs the cryptographic check.
+#[test]
+fn test_corrupted_signature_fails() {
+    let power_table = load_initial_power_table();
+    let mut certs = load_certificates();
+
+    certs[0].signature[0] ^= 0xff;
+
+    let result = validate_finality_certificates(
+        &BLSVerifier::new(),
+        NetworkName::Mainnet,
+        power_table,
+        0,
+        None,
+        &certs,
+    );
+
+    assert!(
+        matches!(result, Err(CertsError::SignatureVerificationFailed { instance: 0, .. })),
+        "expected SignatureVerificationFailed, got: {:?}",
+        result
+    );
+}
+
+/// Validating mainnet certificates under a different network name must fail.
+#[test]
+fn test_wrong_network_fails() {
+    let power_table = load_initial_power_table();
+    let certs = load_certificates();
+
+    let result = validate_finality_certificates(
+        &BLSVerifier::new(),
+        NetworkName::TestnetCalibration,
+        power_table,
+        0,
+        None,
+        &certs,
+    );
+
+    assert!(
+        matches!(result, Err(CertsError::SignatureVerificationFailed { .. })),
+        "expected SignatureVerificationFailed, got: {:?}",
+        result
+    );
+}
+
+/// Presenting certificates out of instance order must fail with an instance mismatch.
+#[test]
+fn test_out_of_order_certificates_fails() {
+    let power_table = load_initial_power_table();
+    let mut certs = load_certificates();
+
+    certs.swap(0, 1);
+
+    let result = validate_finality_certificates(
+        &BLSVerifier::new(),
+        NetworkName::Mainnet,
+        power_table,
+        0,
+        None,
+        &certs,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(CertsError::InstanceMismatch { expected: 0, actual: 1 })
+        ),
+        "expected InstanceMismatch, got: {:?}",
+        result
+    );
+}
+
+/// A tampered power table diff causes the computed power table CID to diverge from
+/// the CID committed in the certificate's supplemental data.
+#[test]
+fn test_tampered_power_diff_fails() {
+    let power_table = load_initial_power_table();
+    let mut certs = load_certificates();
+
+    // Inject a bogus delta into the first certificate. Actor ID u64::MAX - 1
+    // sorts after any real actor, keeping the diff sorted ascending by ID.
+    certs[0].power_table_delta.push(PowerTableDelta {
+        participant_id: u64::MAX - 1,
+        power_delta: StoragePower::from(1_000_000),
+        signing_key: PubKey::new(vec![0xAB; 48]),
+    });
+
+    let result = validate_finality_certificates(
+        &BLSVerifier::new(),
+        NetworkName::Mainnet,
+        power_table,
+        0,
+        None,
+        &certs,
+    );
+
+    assert!(
+        matches!(result, Err(CertsError::IncorrectPowerDiff { instance: 0, .. })),
+        "expected IncorrectPowerDiff, got: {:?}",
+        result
+    );
+}
+
+fn load_initial_power_table() -> PowerEntries {
+    let path = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../f3initialpowertable_filecoin.json"
+    );
+    let json = std::fs::read_to_string(path).expect("f3initialpowertable_filecoin.json not found");
+    let rpc_entries: Vec<rpc::PowerEntry> =
+        serde_json::from_str(&json).expect("failed to parse initial power table");
+
+    let entries = rpc_entries
+        .into_iter()
+        .map(rpc_to_internal::convert_power_entry)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("failed to convert power table entries");
+
+    PowerEntries(entries)
+}
+
+fn load_certificates() -> Vec<filecoin_f3_certs::FinalityCertificate> {
+    let path = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/filecoin_certs.json"
+    );
+    let json = std::fs::read_to_string(path).expect("filecoin_certs.json not found");
+    let rpc_certs: Vec<rpc::FinalityCertificate> =
+        serde_json::from_str(&json).expect("failed to parse certificate fixtures");
+
+    rpc_certs
+        .into_iter()
+        .map(rpc_to_internal::convert_certificate)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("failed to convert certificates")
+}

--- a/lightclient/tests/fixtures/filecoin_certs.json
+++ b/lightclient/tests/fixtures/filecoin_certs.json
@@ -1,0 +1,10925 @@
+[
+  {
+    "GPBFTInstance": 0,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceatt3chdvzyyvyhbyqxlas6kxfct6s5n7tv2gmopkxeh7u7uutpf6"
+          },
+          {
+            "/": "bafy2bzacecdaop7tvkzs4zkgmgls5zuuu5ces4c5dwmhwpamnuihb6disz76k"
+          },
+          {
+            "/": "bafy2bzacebt4u6hnrqio5zhbjcwij2ww3fmw7wyewh5ncjh2paczfrjwi4psi"
+          },
+          {
+            "/": "bafy2bzacec7auqvjuxkm7crhql32nafxt3y6aq5b4xz6zgnjifogt3x67exuc"
+          },
+          {
+            "/": "bafy2bzaceat6ckemcahnpfrbtxchzhdy47lzy7jtqaeusmhi7atoicv2wun3w"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919580,
+        "PowerTable": {
+          "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebowxot7yenqzdxefjlvoj6lzcknsuv6anmwasoioxhod5t5jtw4a"
+          },
+          {
+            "/": "bafy2bzacea55ffsfwql46juws3swb2idty774izkttt2nq7rx6ovfxpjh5x2k"
+          },
+          {
+            "/": "bafy2bzaced45myfddvouzqvhk5b7ixlsefom7dphtsk6fuixbkwfkvha43aw6"
+          },
+          {
+            "/": "bafy2bzaceczcyztz5sownh5pj6c2v53eowuah4ejda4z4h7ldmpnl3uopfcng"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919581,
+        "PowerTable": {
+          "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebzfkgjobgrx7tezccpiu3qtnr54uycpx5navw4of3wbjctui5rii"
+          },
+          {
+            "/": "bafy2bzaceafy7g3pcto7b3zalpz5funmlubbowqqihu7cbi5qstkpveaeac6o"
+          },
+          {
+            "/": "bafy2bzacea3rnp5gvh7o2ufhtbyoayxexgoi7cqahzdl6bgm7k2ktlzsdhkfm"
+          },
+          {
+            "/": "bafy2bzacedoj4v2tc2as3ggqxncoiko55wvcpd4f3gc2im4kza264p2cosaqk"
+          },
+          {
+            "/": "bafy2bzacebokk5pfdsadvmsoytfdjflivkenmwbf3zaqxgsq5l66ehhaeqemk"
+          },
+          {
+            "/": "bafy2bzacec2obop43jh3ekqwoiyqe6bsyhzirnopazax3qe3xzhv5zekjecd2"
+          },
+          {
+            "/": "bafy2bzaceabonawxttaa5c5xwqvrwmakb4yizasnvrat7swl7q3cqvrfzb6li"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919582,
+        "PowerTable": {
+          "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec6mxoqvtipc7zeh2eqguul663lqwj5raqikfun7oc2kb6yk3z65s"
+          },
+          {
+            "/": "bafy2bzaceb2sazh756oqsdct22or5ckhxg5ayw6glt3y3cdprhfqwssncwg4q"
+          },
+          {
+            "/": "bafy2bzaceafctsacv7qsinaeiyrnpbpwjpa5ybvmxajgandx2zsjy3gqhkpnu"
+          },
+          {
+            "/": "bafy2bzacecuzxs2xbz7wjxkpvev7rmj7frvsuciahul42mbt4eb7idcrjiu6q"
+          },
+          {
+            "/": "bafy2bzaceawcqtjmlicxgn35swkbnxsvi6445wheapedh6dtrzh2vjgzoaqrs"
+          },
+          {
+            "/": "bafy2bzaceclethmshlykgubqr7dkifj7iunrhjzs7indpqulraa6xkmmjo3oy"
+          },
+          {
+            "/": "bafy2bzacebdgn7yjosjijn6wbt2bpbpfc2ma7n6heworefbarzy5vl2fqiica"
+          },
+          {
+            "/": "bafy2bzacedmj6aly5tr5tsisdgawhzqvzay7divgucn2yt26owd3oyzcd7h4y"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919583,
+        "PowerTable": {
+          "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedthh4lgwlyl5l4j6y5abkvrnb5baufhhghcwjztf3zobxmhih4gy"
+          },
+          {
+            "/": "bafy2bzaceaxk4soyxov7iiudb6xlnhcdasj65puwv5xc6ohsknpeiddbv4g7i"
+          },
+          {
+            "/": "bafy2bzacecy52wam5hfqu655yhvq4ahyad77wnuw2w6ltyb4nzjejvbofqyh2"
+          },
+          {
+            "/": "bafy2bzacebkx3nwb4qxoc5ou2ftbj264oyksuf3znar2ueqlyv7tynovqrpcq"
+          },
+          {
+            "/": "bafy2bzacedt4lfdhqmowybl3bofr5fayk66b5b23prfelzjtg7oaiaxzrqu5o"
+          },
+          {
+            "/": "bafy2bzacebmh7dtcalxf3xdxmv2qfknmj2xivi6735iat5jnu7eyynatcoo6y"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919584,
+        "PowerTable": {
+          "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebyhwialpvjnjq3vffsdgmilvzrtprmh36nspxcfbh7igox77coxw"
+          },
+          {
+            "/": "bafy2bzacealu7az46cicxuja4kejtfiboxztrjwkwibhudhxsheroppcw6ctq"
+          },
+          {
+            "/": "bafy2bzaced7jpt3mctu3dxgygw5llioy4xvaxl2b6ax6krt6n6t3477v4xhiw"
+          },
+          {
+            "/": "bafy2bzaceargnoppr5rl5ibrfu62eo3v3en2heqe7tjtcjibsgbpesrq5ctc2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919585,
+        "PowerTable": {
+          "/": "bafy2bzacebrcajje5zjvyoklrtwu6ne4zu6js5he6rdwxcxqsxhb2iij7yar6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb6rgsvop4fm7c3qrfgnhtzc46h3qymie7jrf5efox4slpzblrwnk"
+          },
+          {
+            "/": "bafy2bzacebi7wqczpw62unsuzyjvczw6ce6glzpvbzxjvoyglsevyldaaoj6m"
+          },
+          {
+            "/": "bafy2bzacedbay45mb3i4np5netcdle3gs7csflfnw6pk4c6a4fwiauimw2icw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919586,
+        "PowerTable": {
+          "/": "bafy2bzacebrcajje5zjvyoklrtwu6ne4zu6js5he6rdwxcxqsxhb2iij7yar6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebticsj5wcznan5wu6p6jwdz6dxxjjzn2ltohc5cnnpxbnukje2pi"
+          },
+          {
+            "/": "bafy2bzacecnaggh7splsvnldew5odkfp72qb3vr2ud7czbrcxq7wkggrlppce"
+          },
+          {
+            "/": "bafy2bzacecsdxab3czwzlxuvhdzo5rlb76p2jd5me5g3kimb32wag325bvri4"
+          },
+          {
+            "/": "bafy2bzacebife3io7kr37hg4sdreg3yrch75hh6hyavfjxqyoj22krbwoo5ke"
+          },
+          {
+            "/": "bafy2bzacebfthr5jadvedczk5kfu2e3hlzp5tpbyafeknasu4viw63txjidbi"
+          },
+          {
+            "/": "bafy2bzacedvm7marguz7v4jlall5bexifqjdu2gb2d3ot7d2zf4eb6jr54vb2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919587,
+        "PowerTable": {
+          "/": "bafy2bzacebrcajje5zjvyoklrtwu6ne4zu6js5he6rdwxcxqsxhb2iij7yar6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced6hupcodsdu4aulntqgwwsptkzw6iyu4ymoogzc7x66ngxmqud3u"
+          },
+          {
+            "/": "bafy2bzacedzpqwh5nerlxw6e76ytovdjkkx6zphvs6ljg3tgfg5nu2lyogzva"
+          },
+          {
+            "/": "bafy2bzacedvbcyzfjgzmzom7sdx622fbi3tq7emgsr7u3vsptdlouzetpe2j2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919588,
+        "PowerTable": {
+          "/": "bafy2bzacecxvb34rjajfavkw6uhsmiw7wan63eieu5brruriuyz4twf5dpr3c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebhlcn4dotvvo2hb5mgbenpyxwpozrcjddwqufifeo773ftkzkxt4"
+          },
+          {
+            "/": "bafy2bzacebcg6bfygygm3cfx4jqfdhuf7kmigaq25lc7tusscw3hy37ll55xu"
+          },
+          {
+            "/": "bafy2bzacebalwxheprmbz4q5ecqxrh372nmdglkqcc2nfdupuscfldn4svh36"
+          },
+          {
+            "/": "bafy2bzacedaf6s65rzmujxyrec5oi4ydixgcvu6zcxnb2hg6fzzry4et6t7gu"
+          },
+          {
+            "/": "bafy2bzacec2qjirmbycn3f3pohwv2y7alkkzratuxfywoeui7kte2udzfpgp4"
+          },
+          {
+            "/": "bafy2bzacea4vvshkke7s6fwfq5hlm5evzdxlbsuwkt6ilqesnim2hisgugzri"
+          },
+          {
+            "/": "bafy2bzaceb7jypxohpdwlm5foi7rbwwk5eum352we7bnlkgepkgcqgke5y6lm"
+          },
+          {
+            "/": "bafy2bzacectbuk5d7nq7et2wjp4zihhoj5pmkecisluz43eobiiggmpkdqvc2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919589,
+        "PowerTable": {
+          "/": "bafy2bzaceadpmmtioshvopp3uzdkns6ba2kod2yztivavokdvyrhjcvqeuzzc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebipnuyrsnpcqui3raurgfbmqjs5y3xzd5qbihvaaz3osnu2g4uqw"
+          },
+          {
+            "/": "bafy2bzacedwwismpmmeys3kzfjq5vhki4bwukd6klziax243v3xwythlfn7no"
+          },
+          {
+            "/": "bafy2bzacebreg7wbbvgosgkleusnusivqwp5d2n6cwgnfwt6wbrgskalqkhyq"
+          },
+          {
+            "/": "bafy2bzacecxdyxmrmeoyyvgrjxr3vxpxz33jk2l3ctjepm223sinybd5h7pmg"
+          },
+          {
+            "/": "bafy2bzacednwft2tvsyvwmhpqzbpz5vpmwtqdnzebfqm7wtir7bsfl3ypf5i2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919590,
+        "PowerTable": {
+          "/": "bafy2bzaceafrn37eq7rmwwipxb752kunh2hmnj5szzsyp3bojz2tqvw63y7ye"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebwq6joplgygw7ml5zs4sjtyx6n6i23dxjpc7abxdeoeg67hy7ugs"
+          },
+          {
+            "/": "bafy2bzaceapn5dob4j5nghc5tjfrwa5ufrxu5z7foyoqc2ggojb24vy7tagle"
+          },
+          {
+            "/": "bafy2bzacedtba6c4ygoxargpssewrsc4kh4yt7klmjhjs7aflaer4bp6yutqa"
+          },
+          {
+            "/": "bafy2bzacea6vqaw4xaulmohabcbidoeddnk5bmbm26m33ie6mp4ictwbyd6pu"
+          },
+          {
+            "/": "bafy2bzaceaqzbnzzmoziwajn2mon7i27ii6yucjnbcj56eib2helpups3myso"
+          },
+          {
+            "/": "bafy2bzaceaoufluqpog2nxjk5q4rzyb7d7bgbotiesjzis375bwsjrtbr5pda"
+          },
+          {
+            "/": "bafy2bzaceblvh7lmd5w7oqg7cbkrsnceiqgzxnuf42pzvufqwz3gecsoct75y"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919591,
+        "PowerTable": {
+          "/": "bafy2bzaceafrn37eq7rmwwipxb752kunh2hmnj5szzsyp3bojz2tqvw63y7ye"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedhre4b2jcblgv23hhmtnqaydnwzqzvwsspjhdwxfpeems3tvt3j4"
+          },
+          {
+            "/": "bafy2bzacedzhz4ao5nguqnh2ji26unrlruiqam7u2bz5r3jpe3rj6gpp7e5jc"
+          },
+          {
+            "/": "bafy2bzacea2fi25wq4llmgqt4zeb7kn6q5g3zh32d5qh2rgbwk5iu5k6ca4o6"
+          },
+          {
+            "/": "bafy2bzacecpobuw7okku67rh6f6kktiiia2gzcyjqnmg32wz626bmetwhpb62"
+          },
+          {
+            "/": "bafy2bzaceac44saviac2j36bvqau4kg26vqypw3zn56j37yy2cvizra5b523u"
+          },
+          {
+            "/": "bafy2bzacebsub6hcvxt6teqozq3haep3t3agqxhh5a5cx66z6y62fg6cangv6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919592,
+        "PowerTable": {
+          "/": "bafy2bzaceatw3dyaqqwijdkoj5r5rp2mpwx2eu4t4dosdknxbmiubfjr4krni"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebem7xdrtik2hyxzgqgegg3atj4xujdpr6hdbtqeaclvu7mgoohlu"
+          },
+          {
+            "/": "bafy2bzaceapptc56ennrlctqkr2at3yjbmx2i4sroshd5u2ngdgveadyn53pc"
+          },
+          {
+            "/": "bafy2bzacecqvbd2w7bk3nkrvzrx34cowaq7pcp7bfbwuci77zipjauqgqp5jg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919593,
+        "PowerTable": {
+          "/": "bafy2bzaceatw3dyaqqwijdkoj5r5rp2mpwx2eu4t4dosdknxbmiubfjr4krni"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebpsxijyhopyh7oasfrkppbpyvmnkxkblwntgq6hmqbijlot2uxxm"
+          },
+          {
+            "/": "bafy2bzacec6gktugvcyj2ghprowa2agxp3oijzeleadmiwdmbveu3qeeverwu"
+          },
+          {
+            "/": "bafy2bzacebxf6rlqcski4hj4h7bx76jofrktkuny7fdu3fkymgonbuoegbiry"
+          },
+          {
+            "/": "bafy2bzacedffb5btu6dbxscqkn3aiymnpe3g375zvcwcyekgg25kvx54mxa4s"
+          },
+          {
+            "/": "bafy2bzacea3rsn6r5dh5igduj2u2rlzfxjjrvcpqbfcqug5xc2cwkhg5kn2oo"
+          },
+          {
+            "/": "bafy2bzaceahxyevgl4r2bceq2ji2gs3oywpmeb6xqu6kfu6v5pgtoxkx6dabq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919594,
+        "PowerTable": {
+          "/": "bafy2bzaceatw3dyaqqwijdkoj5r5rp2mpwx2eu4t4dosdknxbmiubfjr4krni"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacediyehpk4hlzpvnusvxy7z53vzbfl7z2vtoxhf4bd4pq7xwtodggk"
+          },
+          {
+            "/": "bafy2bzacecwgd6zwno2iwtd7v3efe5we4a36pnv4nm3mg22g2osc2zy2wvvq2"
+          },
+          {
+            "/": "bafy2bzaced42vyx7i43zgllaf3gbumtbkj64ffjndzzjyaat6wg354c6deoxy"
+          },
+          {
+            "/": "bafy2bzacebtlaksz6b3dfo6f2ukyl4ugc7bagx5pj6jlklrzl5xwlijvuhgwo"
+          },
+          {
+            "/": "bafy2bzacedjimjw3cxzfqbcyol45d2r7mr56ykwgfjld672ctca2gq7sqn4wc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919595,
+        "PowerTable": {
+          "/": "bafy2bzaced72enbllwqhxm6cizcyj4adkgio3ml7bssozdugur7wmifyudroc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacead3eoswsnaou2slbzo523evfqf4mtfptvm4mjkq3g3upl3oxlfei"
+          },
+          {
+            "/": "bafy2bzacec377nrzixy7urjhnxt2esbbskg35ivv7tvcgitewb357ghzqqnua"
+          },
+          {
+            "/": "bafy2bzaceag44nkoesuk4hq2edxm4xrqq547pjlhqicwtvwxp67b4pjgzjqhi"
+          },
+          {
+            "/": "bafy2bzacea5s4532rkycc6nio2gfu2p7y5w2bnqqbg7zodewwcu5swagsoiou"
+          },
+          {
+            "/": "bafy2bzacedrnwu3oxiqf36uou3alje47e5izuuafmfjf4eifptotd6cnqd5pg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919596,
+        "PowerTable": {
+          "/": "bafy2bzaced72enbllwqhxm6cizcyj4adkgio3ml7bssozdugur7wmifyudroc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3oc5kinwlbhkksaxmlaabdlgaiaz7wguk6j5xadyff7plp6zyeg"
+          },
+          {
+            "/": "bafy2bzacebfnkeb6q32nxq2hjvjqpdqzujna2lec7urbhi6flxgegx76cm6ts"
+          },
+          {
+            "/": "bafy2bzacecl23wjxbwl525nrz57pwbaf5rziccbh36slrdavf73w4ghiqjlgq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919597,
+        "PowerTable": {
+          "/": "bafy2bzaced72enbllwqhxm6cizcyj4adkgio3ml7bssozdugur7wmifyudroc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebinutbtcppjddrhdeszblt3yiyxbet5n6x362stvc6dnlo3hkf2g"
+          },
+          {
+            "/": "bafy2bzacebecpyqqglftgkzo4i3p4zsf2sb5obi4o5bfacaqqjaw63yiw2vg6"
+          },
+          {
+            "/": "bafy2bzacebikca3mi5cqx4o2rww2mlhtlahnax55mtgrlibq26kmljov7p3dy"
+          },
+          {
+            "/": "bafy2bzacebrvfodojckarza4dhyh3gbygjenug762vx3tobesaxrgznckfr5k"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919598,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec6tpbx6bf67c4sgsz3rud24zhia3adhooj3oky2m7loy6hgyrqmo"
+          },
+          {
+            "/": "bafy2bzacedpnoycjv4qzr3cuzeh2lewsij7dt4vyfrvjrtqp57ilzsxq7pxjg"
+          },
+          {
+            "/": "bafy2bzaceaz6dpurxw7znzxfi6shz42ywsx2uxdcxudjhmmmfkqmvzzt5x7mo"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919599,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      5,
+      1,
+      9,
+      1,
+      3,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      10,
+      2,
+      3,
+      5,
+      1,
+      4,
+      1,
+      1,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      2,
+      2,
+      1,
+      2,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      6,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      6,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      3,
+      1,
+      1,
+      2,
+      1,
+      2,
+      5,
+      1,
+      1,
+      1,
+      2,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      6,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      1,
+      10,
+      3,
+      4,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      1,
+      7,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      2,
+      1,
+      5,
+      3,
+      6,
+      1,
+      7,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      2,
+      1,
+      9,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      2,
+      6,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      1,
+      1,
+      7,
+      3,
+      7,
+      1,
+      3,
+      1,
+      6,
+      1,
+      10,
+      1,
+      5,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      1,
+      2,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      17,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      3,
+      3,
+      2,
+      1,
+      6,
+      4,
+      5,
+      1,
+      2,
+      1,
+      7,
+      6,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      7,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      5,
+      1,
+      6,
+      1,
+      1,
+      1,
+      8,
+      5,
+      1,
+      1,
+      1,
+      1,
+      9,
+      2,
+      3,
+      1,
+      1,
+      2,
+      11,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      2,
+      3,
+      1,
+      8,
+      2,
+      5,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      3,
+      1,
+      2,
+      10,
+      2,
+      2,
+      2,
+      2,
+      2,
+      2,
+      1,
+      5,
+      1,
+      7,
+      2,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      4,
+      2,
+      5,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      2,
+      7,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      2,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      3,
+      5,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      2,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      1,
+      4,
+      2,
+      7,
+      1,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      9,
+      2,
+      13,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      1,
+      1,
+      2,
+      5,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      6,
+      1,
+      9,
+      1,
+      7
+    ],
+    "Signature": "jup1+1e4Xw8ZWZ0OOnXqSXC7icx8TJRn/YKY6tmC9AIQLfHvCwSAbHspQspCnlEDACIASdkTgI/FW4e2RdGwgonIxIIUtZMECWkotXAdJCrzBTeSa3YJ7HuzfEHPwumO",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 1,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec6tpbx6bf67c4sgsz3rud24zhia3adhooj3oky2m7loy6hgyrqmo"
+          },
+          {
+            "/": "bafy2bzacedpnoycjv4qzr3cuzeh2lewsij7dt4vyfrvjrtqp57ilzsxq7pxjg"
+          },
+          {
+            "/": "bafy2bzaceaz6dpurxw7znzxfi6shz42ywsx2uxdcxudjhmmmfkqmvzzt5x7mo"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919599,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecqwmfhvoxtw3sqwhd3qks4sx6wy3bswygqn6d2gw7i5cfhx5a566"
+          },
+          {
+            "/": "bafy2bzacebyhnm5lil7ddeobd3t4didgleakngn6xy5x7kvhxlr3elgqmwfqw"
+          },
+          {
+            "/": "bafy2bzaceakn6ewepsqpg2a4jhcfxwbhkdteqikcpgt3h27qguostil2lgfie"
+          },
+          {
+            "/": "bafy2bzaceadklhrvx42scefy4luytqvutgejq6z7wntzn5e55tajqpt2qo5nm"
+          },
+          {
+            "/": "bafy2bzacedrl77zcxl7xxiavx5voecqva6a4cblnafjt3kqqyqsoo5tyyiwqk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919600,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedhjnrwpwailgbst2s46xh7lzsnnjugbkltepi5hz7nngkinnrg7a"
+          },
+          {
+            "/": "bafy2bzaceabb2dziurer6fohtqum6sfip4byhaz7pyb2dq4vzusttpjb67nfs"
+          },
+          {
+            "/": "bafy2bzaceam4xjxb2i6jku4qp25d3v662cuytt7hgbn25zp3cqgqw75xalpyo"
+          },
+          {
+            "/": "bafy2bzacebvcgllm3uy2vtmeztpoiycm4xr3ur2esg2uzhr5vi5vp6mvun3to"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919601,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceacjaefhlp5gmgxawdjopi4rf27m5laejifydg37al5sukv3whp2a"
+          },
+          {
+            "/": "bafy2bzacec4oz7vu4hvtqiffhgleziuwetug2fmzf7iy4vn4thzw3e2ec3uia"
+          },
+          {
+            "/": "bafy2bzaced25p224xkhjsrxwnmqulnlyf3obf27lctglvltrb7v62mbnumim4"
+          },
+          {
+            "/": "bafy2bzaceboc274jcwzahaqcx5r2fo3epayrmq56uvj2jmsjyufhqtcbltm5c"
+          },
+          {
+            "/": "bafy2bzaceai34itzcz5tj353igciqpxqs2y7hukwgysvxyo5mer6uubjbgbmo"
+          },
+          {
+            "/": "bafy2bzacedwflvbtwg5v3hcgctam77nrdyfmz6hpi5azjorofrvktevizzw3g"
+          },
+          {
+            "/": "bafy2bzaced5dcil7rmh2sx6pj6kdaax6acg4el2qj6gd7c6hn5mvpaxapd4ps"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919602,
+        "PowerTable": {
+          "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea2wnovnvhkzd26nh62dcnyhw2imgw7lcfan7kxn5uf5xhv53cfao"
+          },
+          {
+            "/": "bafy2bzacec6qw52skxtfmwlwdoto7krmyrrxhxfov3iwradb72ikma7n6p6rg"
+          },
+          {
+            "/": "bafy2bzacedvvd7k2wf6vpgdsjuzeceqyyaszinfrdc3rjwnid3vn5ixmgofz2"
+          },
+          {
+            "/": "bafy2bzaceba7napljkt4nvmozhgbixf74evvxabwbqtwnbcaosxfxthkurawm"
+          },
+          {
+            "/": "bafy2bzacedu3r43r46xgqqctkracbdqnbt7fu3vxpvnhr3kwjwnxvaayabhsa"
+          },
+          {
+            "/": "bafy2bzacedjy2ywpkc62p3hywuumwrnd4qoaxf24qqgsnw7vauqlnpdo4tmhg"
+          },
+          {
+            "/": "bafy2bzacedrylzaycbwdffasq2t6q6a7rum7kfjal3mp36wurnpcqondzbdqw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919603,
+        "PowerTable": {
+          "/": "bafy2bzacealcf5lrbgzhtm6jhg23mlfw73r4o4l6tqmmyoqirxdj7742mirtm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecn32s4tpa5lsbtlveatyh36j5it6rcpn2lliqovhfystel7ljexk"
+          },
+          {
+            "/": "bafy2bzacea2if7boz4p7w75kjehmiydfoswad4e3dfblabq7benoozz6obb6s"
+          },
+          {
+            "/": "bafy2bzacedog5rl32bqjjvmyffxjtj5nd5kbwtquw26vyjkfnm7feuwytiswu"
+          },
+          {
+            "/": "bafy2bzaceclvtujxj3grq6lbesgjrfy2ss7afacevel7iu7xl6imhrhibndpa"
+          },
+          {
+            "/": "bafy2bzaceapdofuapfzutc26me5kgjclyz37uwvv63ky3b6tgyrjlq44khdpe"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919604,
+        "PowerTable": {
+          "/": "bafy2bzacealcf5lrbgzhtm6jhg23mlfw73r4o4l6tqmmyoqirxdj7742mirtm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedtqdsjzl6w3smdw2rm23szupotam3eukzj6lexa6zh6ds2l6bmdw"
+          },
+          {
+            "/": "bafy2bzacearsfjqbwr3m3oil43l22jclhqohuzzbb2yd6vdgs3ftspncnhcym"
+          },
+          {
+            "/": "bafy2bzacedfmfkkg6hyczezkyxmx5xavjkphkvay7opyqmyty3k5z5kunvbsc"
+          },
+          {
+            "/": "bafy2bzacedejx3l2kctamdhjral6dwtnp7cfdbq34er3f2nashp5dipmqnq4o"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919605,
+        "PowerTable": {
+          "/": "bafy2bzacedg7xstbvpdwrsavoelxbda4ccb543rqrb3ivkhf7txja7qtjm2b6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebtyto3otlemdoabj2k4xhayphmzubu2pjuitmndrpx7fgv76t3bg"
+          },
+          {
+            "/": "bafy2bzacea5vkzheygwykg2np25qjr5wu3mtnh2nwbkswf5bhxvnuhomd6jko"
+          },
+          {
+            "/": "bafy2bzacec3wszokh6tstbrytli3dstbpw3jnontmnjxf3oudoehz4p5uug2e"
+          },
+          {
+            "/": "bafy2bzacedep5xgtwlh55nu3rlupgay4d6xla2fxluydwjkv7r47v74cg2gbg"
+          },
+          {
+            "/": "bafy2bzaceanflobk5tqy6vqnme2iccusyf5hy74cts6od4xx5htjsm7hlmtow"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919606,
+        "PowerTable": {
+          "/": "bafy2bzaceatpgoqavvlqmpd6fl73zhozpzpx2cx6gt24xjl5ffduizkh5tweu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceakttx7rsptzapozxpfjxzdovbpmgdqgy5etjou24uwb3lkqmejbq"
+          },
+          {
+            "/": "bafy2bzacebomlbnrbzxdswlw2ic4bpzg2hxfrrvcfvhayqxldfxcrozfos3oe"
+          },
+          {
+            "/": "bafy2bzaceb3li5l25oabrz4j6dbwx6pm7ida45p2lraghdrbhxderizg5efmm"
+          },
+          {
+            "/": "bafy2bzaceavfb3cna2f4lpdzphrwjrb3hacdmyxk54ktbegfyiccygwboknx4"
+          },
+          {
+            "/": "bafy2bzacea7pu6lqr63q73bpapnzjmtetirvozgt2golkwblp43irfd2id6ve"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919607,
+        "PowerTable": {
+          "/": "bafy2bzaceatpgoqavvlqmpd6fl73zhozpzpx2cx6gt24xjl5ffduizkh5tweu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedfqnadiblq4nbpak77a22yjh7ysaxgigna6jrvbhgekw73j4suog"
+          },
+          {
+            "/": "bafy2bzaceadj2doxr6ulde3bhnlhpkwwf2nzbfik7elxcdszviqrxzx2shj4s"
+          },
+          {
+            "/": "bafy2bzacedjivtptudggeyr5pva2t3m6rspuwqkbne73whnk2nwgm54uxgbje"
+          },
+          {
+            "/": "bafy2bzacebzfyjffnyn4jcv6pz2rvvrbnnxfpggi26l2hchlbry6n5afgkxsu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919608,
+        "PowerTable": {
+          "/": "bafy2bzaceatpgoqavvlqmpd6fl73zhozpzpx2cx6gt24xjl5ffduizkh5tweu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacect54klfvze2tzybwajnwivtu32nerlqcduxwmkzhwbyhkbefvfcw"
+          },
+          {
+            "/": "bafy2bzacecwoyfov37kkeimeimkjjo2wl2z3vdpixk4gexmsesifujyfr676s"
+          },
+          {
+            "/": "bafy2bzacebj5cgfg477edybyxyftigg2kbc3bfx2h3xoxqboomptmih3f2brk"
+          },
+          {
+            "/": "bafy2bzaceaivsphukxrrzlyiiqvwxywg6m265s7xjydb2iwdvr45sp7auox5m"
+          },
+          {
+            "/": "bafy2bzaced3eydvdyeuwjh2yycz3nj4nedrrfkorq325a5jigswd6s2vsdfwi"
+          },
+          {
+            "/": "bafy2bzacedgtntaivvx2z66l2atdyu272kzp7fzigo5ry5vdx7boeigc7ya6o"
+          },
+          {
+            "/": "bafy2bzacecno336ijfdfbmsumsz5m2wwhw4xo4s2d5cpnquuq5w7tzrghd5pq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919609,
+        "PowerTable": {
+          "/": "bafy2bzacebo5lezgk3bybkc2ausgakkiqukmsiy75clnzviusmw4nqyprh5zy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebp7kyg5expu7ymadxzvz4tortjztyer43tuny6minzkfaw3ucjkc"
+          },
+          {
+            "/": "bafy2bzaceatz4t6sjpt7cbepcwqnlj2gfxqlqvpd77hv57umw5viowqm34oe6"
+          },
+          {
+            "/": "bafy2bzacecjau2khdv5fcht4o6vjgg3nszfgcjdaffttfwy6wwuss2hssgahg"
+          },
+          {
+            "/": "bafy2bzacecrr6a7sulcjrhefhvqfx53jzb54twortrxtykdrqli3lmom5a3rk"
+          },
+          {
+            "/": "bafy2bzacecqavhxdwc5gkt5js552bwlfblkuvjvwpz6pqsc3kzzch6qgdzz7m"
+          },
+          {
+            "/": "bafy2bzacec2hzhuzgwctbku2daxteyzadinabfpa6yptbzxwhql4gnupb4472"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919610,
+        "PowerTable": {
+          "/": "bafy2bzacebo5lezgk3bybkc2ausgakkiqukmsiy75clnzviusmw4nqyprh5zy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedyt2nvym3ptslpkvoh63zvauoaydnmctk73yfamz6qxxk3boput2"
+          },
+          {
+            "/": "bafy2bzaceder4bjupnpwim5dqgurio74xengw7f2a33ppuu672wsk3ypsuxjy"
+          },
+          {
+            "/": "bafy2bzaceakff2n37htvpsgn4emagwwmaqo2bvxxlauzsqzig6yahk7lee3yk"
+          },
+          {
+            "/": "bafy2bzacedou7ixzdm7bgah7hf322auh3fm6enosch4gfkl7fz36rfqyjapxs"
+          },
+          {
+            "/": "bafy2bzaceaj75x4isg43vvcytzvuzka2i7ahcj2ypoa4sumcyxnztgrtlrxwa"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919611,
+        "PowerTable": {
+          "/": "bafy2bzaced2wo7ut7j77swixgf464ef2xky5kvid4eawgejgdaelnzgjykaxc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceajjj32qgdvsbei5dzvt33zrw65tz2v72ddot5phoo52qektadj44"
+          },
+          {
+            "/": "bafy2bzaceco3cnqfzhjzk6wy4zfdc5lwlktod6pmr2nsfydk2xazrxlorosak"
+          },
+          {
+            "/": "bafy2bzacedkvzev4y6wnckmm7obr2ts566fxpqsayyumgiid7uwqxawcx6lv2"
+          },
+          {
+            "/": "bafy2bzaceahbontz2pjyb4slxznx2snzlt3lrwvrrbt23qhp3vvt6xe76uvom"
+          },
+          {
+            "/": "bafy2bzacebdcjbiydlrj55vi7zom2evjfso2u2lflqgfhpkwykvdihchle6zo"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919612,
+        "PowerTable": {
+          "/": "bafy2bzaced2wo7ut7j77swixgf464ef2xky5kvid4eawgejgdaelnzgjykaxc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecys66h3624ubwoy6chcj32y5t4eh754rf2w6eijjhe7s47je47ly"
+          },
+          {
+            "/": "bafy2bzacebozfngchbfonyiqcehgbtyl3ybe4mhrpwq3seypjspxicwcpeluy"
+          },
+          {
+            "/": "bafy2bzacea25rircgdx4n5bdaeovco4mylg6vjqmqvkgg5xhndygpcdrgtuaw"
+          },
+          {
+            "/": "bafy2bzaceb7u76mgsjdm2h6qcfxt47bgheop7xtatrw5o62ekg72du3kdcycy"
+          },
+          {
+            "/": "bafy2bzaced2rucmgnh4fo3omwqtlwoantusmnm4gdk2vrh25uysxfrnjnipv4"
+          },
+          {
+            "/": "bafy2bzaceablpcmfw3yvwr4eeqtahruorlx4sknyrpritww5bl6nnb5o2rdpa"
+          },
+          {
+            "/": "bafy2bzacebbvvwwtbzdiid47m3xfmpyvkyrvtlpdiekd5x7ks5eegamug5s32"
+          },
+          {
+            "/": "bafy2bzacedtz2av4eoyuyqnjqlrzfsg72pbob6bngowbh3lrirrl62cw4csta"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919613,
+        "PowerTable": {
+          "/": "bafy2bzacec5tts3udi4akzfmstfpelpdvjumctdfpc7hmhrbf3p34wyuvysle"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceba3r6w43y34ti3v636qwoccf2tkazcxd2jqogsziz5qqhbzklpq6"
+          },
+          {
+            "/": "bafy2bzaceci5baimjsnold4y7waxde5grdsdqt6gpg4rd5qmq5mb4waxfywzw"
+          },
+          {
+            "/": "bafy2bzacea27jti5r5eudgu4qdpsdalm2zgku3i4zgijuf662pimzd4ujbnis"
+          },
+          {
+            "/": "bafy2bzacea7cf7gzovlvlwvkstqoyyq7a3uj4boe3rxvynvzns74pqykjc7eo"
+          },
+          {
+            "/": "bafy2bzaceci5gev42qj7ys3jfzyfv3erckfpnwcissoerzog6priacy54v7y6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919614,
+        "PowerTable": {
+          "/": "bafy2bzacec5tts3udi4akzfmstfpelpdvjumctdfpc7hmhrbf3p34wyuvysle"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebccenzzty2t6zl3bwbsg37gmz4744ua5eqxnj5pk2cifkdrnoono"
+          },
+          {
+            "/": "bafy2bzacec7h4vmzjj34jx35fyniayhl5xlsh6gvifu7wqp5dtovd4f67ort4"
+          },
+          {
+            "/": "bafy2bzaceanbxaj7s4y2mv7eqls4jcyyvxzzq6bngkn7p7i2gmgbkassptpiy"
+          },
+          {
+            "/": "bafy2bzacebhgqidadromjq3nghp3ywnlpbbnmqzm4b4bvdp4cqcmojuzde4fm"
+          },
+          {
+            "/": "bafy2bzacebqjdxvhpsechcdettx53taosn5vkmmvsah7pjji4xfwwvuziisz4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919615,
+        "PowerTable": {
+          "/": "bafy2bzacec5tts3udi4akzfmstfpelpdvjumctdfpc7hmhrbf3p34wyuvysle"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb6g5mjzu2zzocvnr4os7foe7eepgfx5qpvabwtiztabk5kmtaz2o"
+          },
+          {
+            "/": "bafy2bzacecuzirrlndatqda35x3ohpihtpae4twavzp54iyelyrtlbyyadm2e"
+          },
+          {
+            "/": "bafy2bzacebve4c4nqaxacheitvdkbde473odyt6zmnjf4vedvhbzgfpidv27e"
+          },
+          {
+            "/": "bafy2bzacebw5qmhcsxdzdesd4cnziz4wpjlvhr5dglohxonmcbow7douc7fqm"
+          },
+          {
+            "/": "bafy2bzacecbpymd5vukibzg7op4to7bbnziblwkfxbrhvvjn5fzpwp3qe5ucm"
+          },
+          {
+            "/": "bafy2bzaceccproio6aahatovkm64uap45chs6sstp7nupxry6gta3y4hubgb4"
+          },
+          {
+            "/": "bafy2bzaced4mxpiic6zdzchb3ycgfwygiebnjsv5uk6z3iujtobk6ajzo7c7e"
+          },
+          {
+            "/": "bafy2bzacebswdde6reiizoxcdt2sx4irpi6qqamhgqvlxoiq3iqjlc37mtyo4"
+          },
+          {
+            "/": "bafy2bzacec227lg2wpr6e33a56ess753tofu3lg67ebs3tnqsafxzbgrwr2lc"
+          },
+          {
+            "/": "bafy2bzacebd62fq63sfm5z3ccpoidxhoeddyl7fooqzcslquug4oebdnsvlfa"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919616,
+        "PowerTable": {
+          "/": "bafy2bzacec5tts3udi4akzfmstfpelpdvjumctdfpc7hmhrbf3p34wyuvysle"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea53lldlnixntdi2cw66jwwevrwawamz2ijwcsgccomcwkcb5254s"
+          },
+          {
+            "/": "bafy2bzacecelozsedezm3kjt4ejokkwsftw7xcp6fv5wpethnsswrken4ybe2"
+          },
+          {
+            "/": "bafy2bzacedlmxb62x4xov2drwjsq664wqhxaqexcrroeknjnyagwlvv7vvhug"
+          },
+          {
+            "/": "bafy2bzaceaiwhdra6br6o5gcq7w5ond74qt2c65vtzhhdvtrhcyk2swzkun2u"
+          },
+          {
+            "/": "bafy2bzaceaqor4riqyofway7k2huiwhyiytlxwklbbvwki2qf7qqa7olzc6zs"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919617,
+        "PowerTable": {
+          "/": "bafy2bzacec5tts3udi4akzfmstfpelpdvjumctdfpc7hmhrbf3p34wyuvysle"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacectyqp3xhngkwdrkdc2ph4gdkwwxyqxzptn27pe4myhivvqpugbu6"
+          },
+          {
+            "/": "bafy2bzacebyozz3c6zbyivxia5uze527ktb3knpkbhwzz75r7ntao6ttbrhsg"
+          },
+          {
+            "/": "bafy2bzaceb2ge4wweejaitjzrxbvbnsx2jj435tyzml6ai23v675asmzgk5ao"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919618,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      5,
+      1,
+      9,
+      1,
+      1,
+      1,
+      1,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      6,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      6,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      6,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      3,
+      1,
+      2,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      5,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      1,
+      1,
+      1,
+      13,
+      1,
+      1,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      10,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      1,
+      7,
+      1,
+      7,
+      1,
+      3,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      6,
+      1,
+      1,
+      1,
+      4,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+      1,
+      3,
+      2,
+      4,
+      1,
+      2,
+      4,
+      1,
+      3,
+      3,
+      1,
+      16,
+      2,
+      2,
+      1,
+      1,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      3,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      7,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      12,
+      1,
+      2,
+      1,
+      1,
+      1,
+      4,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      1,
+      2,
+      1,
+      5,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      4,
+      2,
+      5,
+      2,
+      2,
+      2,
+      2,
+      1,
+      4,
+      1,
+      3,
+      1,
+      3,
+      2,
+      3,
+      2,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      10,
+      2,
+      2,
+      3,
+      1,
+      2,
+      2,
+      1,
+      4,
+      2,
+      7,
+      2,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      5,
+      1,
+      1,
+      9,
+      4,
+      5,
+      1,
+      5,
+      1,
+      7,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      7,
+      1,
+      1,
+      1,
+      9,
+      1,
+      4,
+      1,
+      2,
+      1,
+      2,
+      2,
+      7,
+      1,
+      2,
+      1,
+      1
+    ],
+    "Signature": "gxFgH84vK7LLy6RGYAKD80d626OJJWb4j5b/7WTWumUJWoRcK/pbM5REZo+I7keCC1kj4yaBHwW0mlHsBktzIhD/SCegHcwBd30TTpw8TWplB0L8PmbTtYiRgq1GHGOy",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 2,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacectyqp3xhngkwdrkdc2ph4gdkwwxyqxzptn27pe4myhivvqpugbu6"
+          },
+          {
+            "/": "bafy2bzacebyozz3c6zbyivxia5uze527ktb3knpkbhwzz75r7ntao6ttbrhsg"
+          },
+          {
+            "/": "bafy2bzaceb2ge4wweejaitjzrxbvbnsx2jj435tyzml6ai23v675asmzgk5ao"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919618,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedxmjjpa6h23c4bjdgudlk5757hfcrligipyfupryj4llb3jmzmfm"
+          },
+          {
+            "/": "bafy2bzaceaiqjkqlpnkz7mxpliosbc4lpjcoibsyods2dof43us6q3n5zclkg"
+          },
+          {
+            "/": "bafy2bzacec765q5jkxnwgxrloih6nwycis3qk7fu5xdfxy4hmpdxgdn7mht2o"
+          },
+          {
+            "/": "bafy2bzacedcm4gkodctcgnv2nrwganis7ad4cstp2vn2mcmgf7pdkg2nqwgby"
+          },
+          {
+            "/": "bafy2bzaceckjdpkw3ipdwn2dgkoqnzwzums5lgmm4deifpf5brnh66kqsrpzc"
+          },
+          {
+            "/": "bafy2bzaceatp3km6ikh6sh5pi2m7kp46l3ucr7nsth6xzfah3cskj42vtxuv4"
+          },
+          {
+            "/": "bafy2bzacecwudgywb6qpgjydwdj5rv4nqwq3i4hulvw7l2crilyodo5lersq2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919619,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea4jcagerh2ccv3zdz6srmavqnvrgyhnkcvz33hl7lkfyhcuunvfo"
+          },
+          {
+            "/": "bafy2bzaced5tkmo4i6anidvhyibhkwqowycdvw24ootat4muzpi2irjlnrzke"
+          },
+          {
+            "/": "bafy2bzacedrfhmxmyiq3tqxoeckqbytuhitytnpfzhucuyjaw6uo74vr3dqja"
+          },
+          {
+            "/": "bafy2bzaceasnl37zlbgmbqfwxoks4bvpyknp7uaqlifqkd6g35j637smy5myu"
+          },
+          {
+            "/": "bafy2bzaceaboty4f4zuo3bwkeabospivdadtubcms36ykegionppkoddfpvqe"
+          },
+          {
+            "/": "bafy2bzaceb5j65qivb56nn6ljpnfqcwsvqespy7loclh63pmyvyxlglkkdmxu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919620,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceah5dtw4ih6kjw4bmixxfuf44s2mzbbwusi26w6eul344qfmqyvwy"
+          },
+          {
+            "/": "bafy2bzacedxa42tkcug45vrfd46ike2q4qsjrbcw4vwbtd7xe7cv2ta73pxb2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919621,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec7orr4zc73ja2c2i6ablxgj7ggsdqbxgfn5mf3rfpjwbml6g66ss"
+          },
+          {
+            "/": "bafy2bzacedhlirbc3poxldyoespbepegemnis5idp3e7gklvh2wp77ldpcwjs"
+          },
+          {
+            "/": "bafy2bzaceb4afm6kelzo7rsc62igrlgx4oc4l37rjw6urtwenqjw3qta6vr54"
+          },
+          {
+            "/": "bafy2bzaced5yunnc5ekhxzvdkzghdvyznztuvkqktcrt4acy2rqpsoihwn65e"
+          },
+          {
+            "/": "bafy2bzacedbwwbdoilqe5bmkc3emucd4fumcgqupeendwuv2vrrazl5syiu3s"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919622,
+        "PowerTable": {
+          "/": "bafy2bzacecw757aij62zne7dtsuggukyfd6wqbatnkivgt6br7yqmeg3acocw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacediv24vagu6qth7u6lrvrdsy5tyhfurt3vikjoy4ju2looh7dl3bc"
+          },
+          {
+            "/": "bafy2bzacebioma2jes265sfhvzrnpnhsvanjruaercr6vrmxnib3s25zyes6y"
+          },
+          {
+            "/": "bafy2bzaceb5e6jcs2me64r3fwiyb3svolifxuhekimpqs6hxqo2isf3afuigy"
+          },
+          {
+            "/": "bafy2bzacedtztluawuboijo5ov2ywg22lgp2fpsuc3jzlpielik62jb44bly2"
+          },
+          {
+            "/": "bafy2bzacecgvknggunwgy4hwp2s7r7sgoqduvlnaatn6p7xd6p6p5qhmxvmma"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919623,
+        "PowerTable": {
+          "/": "bafy2bzacede7fx22azeqrbnsla5xjcpnvwqeymbx4wu2hxpyqgvjbaddnomdq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebfuhlg2cllbjcyy3yfsqo5vphncxgjsc47xuwbpvzvn5nellgd4i"
+          },
+          {
+            "/": "bafy2bzacebxupwu6ixn7g6ogaspuscfiei32tuwqsn6t4gobymvw5twmukjm2"
+          },
+          {
+            "/": "bafy2bzaced6bhjfchdiz3uube7h34x72cb2l5b5mdtm7svsl7q4lpti6pkqyi"
+          },
+          {
+            "/": "bafy2bzaceasmkw6pyy7iplpckjr3ymqmeo7hfnm557xnabzpjkvbjel6n4oke"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919624,
+        "PowerTable": {
+          "/": "bafy2bzacebj33xukjyiucut2k5htnxbaj7lcxsloz6vpe3rtgenzn7k6dp6wi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedvx5ei3jts66olxw2unxerihzn6uz4qogqd445sfj7zfw5eh472k"
+          },
+          {
+            "/": "bafy2bzacebtjuidcavbmqkhlpikdzj6ltscv4sntv5vuaqferni2277jo6grg"
+          },
+          {
+            "/": "bafy2bzaced4w53ocmqale3djukx4rqo7mac65ofthiyjmgkqat4vp2wgasaq6"
+          },
+          {
+            "/": "bafy2bzacedj4uhsq6434wasved27fxgrzoiddl2za56lil3qmlh3kiog7jda2"
+          },
+          {
+            "/": "bafy2bzacedrpfhvfqxekfxl3ogwfrcvmdvfngzntsf72kcrmyrgvwqb7ziwnm"
+          },
+          {
+            "/": "bafy2bzacec76i7omujri3i4qlcyristr7ak6zs4cr2ne4vciqrjpidfdbuzhc"
+          },
+          {
+            "/": "bafy2bzaceda5jw4t2occahgx4kfcch6p5vrmqd5bqgd2xwfwfalzcl42guuqy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919625,
+        "PowerTable": {
+          "/": "bafy2bzacebg2ajdezq4g2wndejfmjm4png4zsnukymc3shjsrr7yuixgbhaqs"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecq4frpu6la5kujexqi3kq3vfwysdn7yarfrykqu45j5f3ya6uazk"
+          },
+          {
+            "/": "bafy2bzaceaqhwa3zxmlphjl3qpufhgclzoeiurprzxlijgo2akokqhkxjf3hg"
+          },
+          {
+            "/": "bafy2bzacebeet2pzp3ztt2dtbngipbvynpf4c25iu2vuigpt4d7ncxlqkutg4"
+          },
+          {
+            "/": "bafy2bzacedgwlcimoxp75f3mo4xh6e5y5q3ewzgsim7xfr4dycqk7wn3ohqs2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919626,
+        "PowerTable": {
+          "/": "bafy2bzacebg2ajdezq4g2wndejfmjm4png4zsnukymc3shjsrr7yuixgbhaqs"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedj36oc5e4gd7k4tuk5o6hdttg67voxt7fssp7rkiak5dorwj6rna"
+          },
+          {
+            "/": "bafy2bzaceaj6kxxv5vnpubq7fnulb6hftqyv7qzfwx4fu72puoqxeinux4bvi"
+          },
+          {
+            "/": "bafy2bzacecwm5pketeg55jcatpibwcvkzij6hk72nutzbj3uwneaxswzxerti"
+          },
+          {
+            "/": "bafy2bzaceagatdyl4tircw7cyfips2ol6uuewag5n7j5hpf2wuvcohv3toifa"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919627,
+        "PowerTable": {
+          "/": "bafy2bzacebg2ajdezq4g2wndejfmjm4png4zsnukymc3shjsrr7yuixgbhaqs"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceackizaiyw2wvccutebl2ucwbv3sg7xtei6sgtfftns7dy2fvnjj6"
+          },
+          {
+            "/": "bafy2bzacecfiwlgzuqyxzospdnmste5xiiucx4qggtosfo7lddmlxs3i676bc"
+          },
+          {
+            "/": "bafy2bzacedihwcgpedciezvpjf3a4ctw4jty4xsf4cphbj642xrq6pzdycagw"
+          },
+          {
+            "/": "bafy2bzacebtowdhkgqfihw2go27x5jfyssfd34idp2r7qwwxdouttdmlfprbs"
+          },
+          {
+            "/": "bafy2bzacea62x6yewhep7d3f3bqfvkfkpzb2grtj3z3htrtmfwcsij3vrcyue"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919628,
+        "PowerTable": {
+          "/": "bafy2bzacecpge5d5sm6dcfckk6c3ez4mbodoidxh53dnui6bdsfzpvjv3msak"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec3m4dgyvavwptlg6xyyzl6osktdfzpk6y6zwodjcrsnnj53ucbsy"
+          },
+          {
+            "/": "bafy2bzacebswcqxuu5kcntk4ux5xtkjlnfzh6f34jl75s44xqpwxeogne3j3a"
+          },
+          {
+            "/": "bafy2bzaceccyvpw6dklcuk4vpb3t5snb5yjqsemvn3cuxcgeq6vovgdepumqw"
+          },
+          {
+            "/": "bafy2bzaceaq5cjksulcr47uwkwgeaveyi3ykuwey4ink2qop342hhwnru6sc2"
+          },
+          {
+            "/": "bafy2bzaceafu64zz3erqrpyplywhct2f3su3oygbjopxe3gab25jdcwhscq2m"
+          },
+          {
+            "/": "bafy2bzaceca7vn5kz3wlklgesk4grhz2rdgmwzjkwdps62xlo4nw66opcvrko"
+          },
+          {
+            "/": "bafy2bzaceb4yxvhb2ngvdjrsst72rkg75772zhitvf4wdilleqeyfmaaiwzze"
+          },
+          {
+            "/": "bafy2bzaceczdbm7da6t4t7fj7agw6ycc3ltxhoffzqopjjc3abhkrjcc64b7o"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919629,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebdsd3vdsaruqynyqn5caswkorzz3lhpawo67mh44fwj74wa2zn4o"
+          },
+          {
+            "/": "bafy2bzaced2shy3i6imb54zxlixllpuja2xgaebmmqsm6wxps5qwi6nm6sgv4"
+          },
+          {
+            "/": "bafy2bzacedxhrwn7baoz7sicmjkhira37j7qqrgs63tc6pqkosa5y3da4bits"
+          },
+          {
+            "/": "bafy2bzacebul3j3lwqwz5j7fqvehgqf5jdq553ccxj2zb54nepyklcvu3kwyo"
+          },
+          {
+            "/": "bafy2bzacedqcvqempm2rnr6ncod4wuoarjm57lek75os5wj6lxc3rez5of45g"
+          },
+          {
+            "/": "bafy2bzacedianxio4pigi2qkbzsf7mz2zyccrcycbma6kb5mr6ghyqcgg62ac"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919630,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced4qqstai27ss4ztqlbpuohmmxdaywl7vuecldni7vgjhnb5keg6g"
+          },
+          {
+            "/": "bafy2bzacecgtf6olmzaidssi3rzm52ycmaehty2kaduh2ta4mgbi6bwpydrhw"
+          },
+          {
+            "/": "bafy2bzacectrv45n2cuauot7vy5parpzlllbtl7gplml3hfvnjjnwj64mhju4"
+          },
+          {
+            "/": "bafy2bzacedthwy6xdap7c64zgcc7i7qnlg6ntsqypjev74ioswawkzzoelwu4"
+          },
+          {
+            "/": "bafy2bzacedllza5dlw26khiwuon2tx6yocums5in467y7gs3dgeov6gz3vk2u"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919631,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceanplluxe52h7hijlxqu74m6ypnmvcpmyth7cljzf3q5lvsuzsr22"
+          },
+          {
+            "/": "bafy2bzacedetttn6m6gaj4mhg23ifsqqzbvryd7txt7cfv57qn7nnbsdgymeg"
+          },
+          {
+            "/": "bafy2bzaceao6mgzbtbmvuv4nmziqdjvl2csy7lkxi4q625xkvho6354i645fw"
+          },
+          {
+            "/": "bafy2bzacec4vga2mlwvvg2jhqvstzei5m3xjeirtotrl4g5rkympy3msj2oem"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919632,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceazr3gkoutii5kujx2jjbrmp7ufmmmslpddt527lyirkg6rkwd6oc"
+          },
+          {
+            "/": "bafy2bzacebvoa3uyngfwproolobda23etmlxn4ckean5ucy5cbfyxfh472ua2"
+          },
+          {
+            "/": "bafy2bzaceatfixyjggqasmf7fd66uz6kqro4gaosaaignes2kibwkrju7aceu"
+          },
+          {
+            "/": "bafy2bzacebo46wknymkbynnezajuppauta4elekwobxrykxhflsgmnow33ioc"
+          },
+          {
+            "/": "bafy2bzacec7uvirgbwwisppg7ykz2kqyae7gaszharfsidoovrmmm63doswla"
+          },
+          {
+            "/": "bafy2bzacedtz7jrfzwsj5r4bt3gtilkhyicqpff55gy762w7jar6opnhsspwm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919633,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedxajad6qlcupfoknr4jgt3bw4h3ryztwtv63rj7hn3plwdv2z2bo"
+          },
+          {
+            "/": "bafy2bzaceavcf6dfw5wwicjmabyzna4nhmsoeqxzphq7i7bxcwikuzlncs7c2"
+          },
+          {
+            "/": "bafy2bzacebraxs4h5wy7s7a73h3hy67hk56p6tgj4z2ngy77cefglju5tjbxo"
+          },
+          {
+            "/": "bafy2bzaced4742sbzavesv5ejoxklouhyw6in3ghjefewgwna6wa6nsmojgus"
+          },
+          {
+            "/": "bafy2bzaceack7axturgojn7gc2462hbswuifnx2yrabm23oy5e4h7abwjmm62"
+          },
+          {
+            "/": "bafy2bzacedohr3kyt5daqbuxywloohphweufc6t5uj53xlq57sdresjwzakmm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919634,
+        "PowerTable": {
+          "/": "bafy2bzacec7nwyj2ig7mh3geud5n6kp4octkj7ykz7ti2gtmyw2wt52ucmm74"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedmu3tmkxfuq2nwruflyr2wbbsdsujliv23fxp24x7fiveh2qwq2c"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919635,
+        "PowerTable": {
+          "/": "bafy2bzacecaxm3hwv3xni5r5ckea63d7fytuqytbvncjoimbupd3ogvvj2dqi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebjnovrxrgupxw7xlgtenovqrvcb7ybrz43mrtm4rdtg3gj4ww5u4"
+          },
+          {
+            "/": "bafy2bzacebotyoop7zdmchralyi6bp7na7u4sw4rpvryzeu5jihsdg452weje"
+          },
+          {
+            "/": "bafy2bzacedetcene6qzf2o7bkicn7nkjhecwyemx7ji4tr4z6xyalu2s7p6dc"
+          },
+          {
+            "/": "bafy2bzacedrszy7z56232jjn3frskafcxfki2ghblu4endzoqur26mdmjatmc"
+          },
+          {
+            "/": "bafy2bzacedz3ger7pkympraf4dufcwkmsj5s3uizrz7cmuvwl5t65gdcca5xk"
+          },
+          {
+            "/": "bafy2bzacebf2o2x6nzo2lyxxhjvet46fsjjfkadkv3wik35rz4itxn6yle6qc"
+          },
+          {
+            "/": "bafy2bzacecszk33qpazgjqorcope2gm3yxpyjwbgi3ywch2jivhaejftcbdju"
+          },
+          {
+            "/": "bafy2bzacedr3xj7niw4vkfasiw4n4nq4auzupkwh3io2wnlc5g4vbsub6cvoc"
+          },
+          {
+            "/": "bafy2bzaceavdoyr6iahmmpkmr2u47wznuwlf2mmyqioi7lfstprotyna3tp4k"
+          },
+          {
+            "/": "bafy2bzaceawfoeejgknqcqum6joo2z5ovt2nb6dkrbgxotgavqd3wnog44xwg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919636,
+        "PowerTable": {
+          "/": "bafy2bzaced5wdbgqzpxyktg4epjs6jq4pq36wglvvd67vpdz4cysgoioe52hu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebcgrpvc4hg6a33h2zxpwndgaul6iaooj4zfooiiaw7gqxxtunlcs"
+          },
+          {
+            "/": "bafy2bzacecl6a6hjbnmx4wsg3shw2qv6kchpjwqfiltkjr5bctigsoaqtzmiy"
+          },
+          {
+            "/": "bafy2bzacec4phplm3mucrkbqhng72gukubtpv4czv6kv7lsdbiaguwqxyl22o"
+          },
+          {
+            "/": "bafy2bzacebxge7bt2ax47h2zqqrpv2lgwpkpqdctonng5i6e6berpwyivklm2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919637,
+        "PowerTable": {
+          "/": "bafy2bzacea26udkssai4j2nkcss37j4w3mcnhdyup4xbaeih3ao7c5y5rbv5i"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      2,
+      1,
+      2,
+      1,
+      9,
+      3,
+      1,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      6,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      2,
+      4,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      2,
+      1,
+      2,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      9,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      1,
+      4,
+      1,
+      5,
+      1,
+      7,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      2,
+      1,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      2,
+      4,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      8,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      1,
+      9,
+      2,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      2,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      12,
+      2,
+      1,
+      3,
+      4,
+      1,
+      5,
+      1,
+      2,
+      1,
+      2,
+      2,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      11,
+      2,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      2,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      2,
+      1,
+      2,
+      3,
+      2,
+      2,
+      2,
+      1,
+      4,
+      2,
+      7,
+      2,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      2,
+      1,
+      9,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      1,
+      1,
+      2,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      1
+    ],
+    "Signature": "skl5pbw38iHQAWCphde7OZTZcNxD3uaLy282975hLdAHa82cdZsKlqHc9BCxd0WyAjdAmTrhUUPeNI6dv+JEegKxuBfjN/A5u92b04L+XdNErYZ7OH9pf56Av1TKEFZj",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 3,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebcgrpvc4hg6a33h2zxpwndgaul6iaooj4zfooiiaw7gqxxtunlcs"
+          },
+          {
+            "/": "bafy2bzacecl6a6hjbnmx4wsg3shw2qv6kchpjwqfiltkjr5bctigsoaqtzmiy"
+          },
+          {
+            "/": "bafy2bzacec4phplm3mucrkbqhng72gukubtpv4czv6kv7lsdbiaguwqxyl22o"
+          },
+          {
+            "/": "bafy2bzacebxge7bt2ax47h2zqqrpv2lgwpkpqdctonng5i6e6berpwyivklm2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919637,
+        "PowerTable": {
+          "/": "bafy2bzacea26udkssai4j2nkcss37j4w3mcnhdyup4xbaeih3ao7c5y5rbv5i"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecbw7nkuzkerxcmqz3f5jnef7ra3hwxrujvo4zqgjh3vg565p6uv6"
+          },
+          {
+            "/": "bafy2bzacec57l67rs6xugz43igz7bnkdeg53t3pkumdsdn5bwjbaldtff6v6i"
+          },
+          {
+            "/": "bafy2bzaceaytpbn6i4usjvljhspqaugb7kddhs6ul4uamfu5ucunycon6fxmg"
+          },
+          {
+            "/": "bafy2bzacea7jf2wva4byvieqtxtyj3h2vshkymo56qrm4kzzrozqxooij2org"
+          },
+          {
+            "/": "bafy2bzacechy7in2pwzn2noqvwlv6vhzfkrucrlvokqztomc6uxwd6kmk2dpi"
+          },
+          {
+            "/": "bafy2bzacebwy7ci5vecx6hgr75wqgya67kkh5bhly6ru2fb6marexknqawaly"
+          },
+          {
+            "/": "bafy2bzacec7wsxzygdjsdkdi4oiwoxypmweekwje35dbwiuphpf3druav3wda"
+          },
+          {
+            "/": "bafy2bzacea3tb24cdigfdzdtikdeuhkrqs5pcfqehgz3a5eru75qki2kf2o5e"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919638,
+        "PowerTable": {
+          "/": "bafy2bzaceddy6j22tunqu6ndaapk6y6n4hzgljyy5hp4mm2itzb4hh6zp37i2"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec3yw7iy2qivqiuge2ieaugjyxc3mrsudh3llo6zwxr6enugtnv3m"
+          },
+          {
+            "/": "bafy2bzaceazsodkkcbq3ik66q63rqxurclslitovjbm4m6cbrrz5u4z6nlo5c"
+          },
+          {
+            "/": "bafy2bzacebslcj7zpzxigfhatczwnv5uqmvlff6awlc4s7ngechkxzc6tx536"
+          },
+          {
+            "/": "bafy2bzacedcmhetbd3avvyto5mcgz2vgaf5evcev2ynfsbup4fa7g57bwjkx4"
+          },
+          {
+            "/": "bafy2bzacebeygplmbvey2l4jwawhkpkbpqvncb6guhsq2p2m2mffwzfes7h2o"
+          },
+          {
+            "/": "bafy2bzaceak2vascm2wi4n3rarwqskzticd2u4nzvwhznljyk6ho6ubdauh7g"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919639,
+        "PowerTable": {
+          "/": "bafy2bzacea6v7vdvgdyvhd466tyt5bw3uctoxv6xtg5pj5eyktbs7swgzpyh4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea7y3d2ricc4avkqz5njhrluytwjpm5iphm4gaehbwcd4nmrzyu5k"
+          },
+          {
+            "/": "bafy2bzaceddu6omq6uswetodjiux45lv2k5ssajmq43ppzkdr3rfh4swxqkga"
+          },
+          {
+            "/": "bafy2bzacear5iunp64r2g2irhmvxmpdb32pizbk6i2xnd3utn6w6m3deemnni"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919640,
+        "PowerTable": {
+          "/": "bafy2bzacecdae3juhxqdmep767jjl6pnw63qim3tcrqqy6dpnhmi7sxnepbuu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceas3vk2qfncp6mcqviaeyqyquulcao62stwn45zdms7jmcofmdsam"
+          },
+          {
+            "/": "bafy2bzacec5h4hoveld3bg5kskq3rgbvfnqgvfas2ibvfhnhaeoilxhasehhs"
+          },
+          {
+            "/": "bafy2bzacea77hcrkyerqenmjti4uu4w4srirhi6qhrb344x3ur3ng6rkfbyom"
+          },
+          {
+            "/": "bafy2bzaceasaurkoq4q4i3k4bnpoewjyyytueq7mg72nxch676jx7lqi3nxfi"
+          },
+          {
+            "/": "bafy2bzaceaw33dwx4dykfk6hsnxfxjp7s4jwuov5w73zmtbr5rhy4cxsms3jw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919641,
+        "PowerTable": {
+          "/": "bafy2bzacedkqml2hwpdnqsh2gm26ar4qkhqo5ic3p7edyarhln35gygk3fknk"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedtvjrfch7e4my3ucphoioqw36dv7yaals4aynjnlepwnhubm37km"
+          },
+          {
+            "/": "bafy2bzacedxvhia3k6eq2c7whazabilwmp5fqvjgrwfsojoasr46i3geby626"
+          },
+          {
+            "/": "bafy2bzaceanhbpaduga2uajbxvhnbcx6gpji7owlo7hqqv3jmaebvv7dl4lqg"
+          },
+          {
+            "/": "bafy2bzaced22ty6bt2kowcspxyu3a3n7vosc4y3o3rv3dr7wcwczoyfy72ews"
+          },
+          {
+            "/": "bafy2bzacebmm7hcjolzh5flkwp5gymratavugiuo5ahtlhhicuuzeravgbb4g"
+          },
+          {
+            "/": "bafy2bzacecoxnd3gmcc5tb5eyoukejddwflwzn5lukdxit6agizg6dn4mot3e"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919642,
+        "PowerTable": {
+          "/": "bafy2bzacecu7gcmmkse2aqbv5ns5ayo2veid3yehtsvl5pfwo5tlmthu6ihes"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebfrz237zumz64zgqfgdnpuyzh42aqtejqlejwrph53d3kefrpo4q"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919643,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebr4amyozudimblb6crjthjbqkbdsg5m2c6tvqeabwqjzl763kyps"
+          },
+          {
+            "/": "bafy2bzacecgfcgjhyro7itgxkwmi3dqbkwis7pvd7ntmw3kdkjrijrpqgq5ja"
+          },
+          {
+            "/": "bafy2bzacecxaam2dqt4esqcpeuwaix4stlckwxk3xrvroblyzd7uyujatqk44"
+          },
+          {
+            "/": "bafy2bzacecdldroivbm6iyz4z2tfznrfp2th37soggbzsqqnlezfg5tpxti3y"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919644,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedddpfye7halgng25k4smnzjowfiwiipnecaqbrgwlqsfglr62wre"
+          },
+          {
+            "/": "bafy2bzacedz7ith4li6i4qsiw7uaca6whrbvylw3ft6odhpy7yh3ppyau3lbi"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919645,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecehpifm53xq2xqpjk33t3oqio72wyahaafkhrqpscjo66gnav7jk"
+          },
+          {
+            "/": "bafy2bzaceb5pmfmccrhqytlygg7e2lmx24znr7ls45hrd35t7h5ia67zjqv66"
+          },
+          {
+            "/": "bafy2bzacedulzxefbibsrhz77wyqdblhkjvjcc4pfj37z4gdlrpnuebnk45yu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919646,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaqvehcp7iptrcq5jdnfxa7xdmtl5vxqleqf3kuedvphviag6xufq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919647,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceadhpkxkh4fepkc6cmpykeaarnaw22cgdlzrnwsttnvupjolic57q"
+          },
+          {
+            "/": "bafy2bzacebf5cmybc7yklsqcqxfv5jqz7mwr4l4jl36vmrj5jnx3uooffpmtq"
+          },
+          {
+            "/": "bafy2bzaceaaauxt6g6k3upzzogfyquwy7xks57artmr3rxll675bnkrn7an6u"
+          },
+          {
+            "/": "bafy2bzacebfuv6f4ious3osylnu4idj7kr4sjlu4iiyuxahh2bpstqwd4yi34"
+          },
+          {
+            "/": "bafy2bzaced5x2oqdz36dhjmpbt6di5kzht75bb35afkx3frmv7dzkxb5rbeli"
+          },
+          {
+            "/": "bafy2bzaced3zi6ajdw6ecqoqnbp7lq67544byl2hxd7do2ewyvfw4trfgd5u2"
+          },
+          {
+            "/": "bafy2bzaceadttkunoced3e6sdh6gw3o6f7crzcaraajv5okjntihnrjtuicqc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919648,
+        "PowerTable": {
+          "/": "bafy2bzacedc5oniltp3e3sqh5fu3vybap2c4vjcpoqlmmi66xdr5pgwxh5uoy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea5xhmmrvkbb7xzw452z2tarbthd7nkuzv4fnt6pa56g4j5ldaz6e"
+          },
+          {
+            "/": "bafy2bzaceaz2awekgnt7sbmokxugaeuwmtjc7hsjseyxwbx5ko2pg7cbw7uwe"
+          },
+          {
+            "/": "bafy2bzaceatc5pyoawc6myoddhrsapzxrj4emdusm6rcfbtzhvalwpws46azk"
+          },
+          {
+            "/": "bafy2bzacecbrcw3qxr6cgzg5nsupkkztxz7rtricx3kmhasmysdrrtsy4jq2c"
+          },
+          {
+            "/": "bafy2bzaceacv46t2japuojeorxlyysjscapjvyvb7jzpzhuhvgcdxzapjr3re"
+          },
+          {
+            "/": "bafy2bzaced7l5jyfralpkb4yqgzlmtforrbzt4khmfh7l5rw2icgto5eyx6ue"
+          },
+          {
+            "/": "bafy2bzacebwhpgnvtvob4cx7dvq2de5czts2jjv5yads4lqwdx72trgljqyrc"
+          },
+          {
+            "/": "bafy2bzaceasu36pyvcqk3qzrjet5ddph3az2ytq2w7l75cjqzpgkwhb3gw6yk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919649,
+        "PowerTable": {
+          "/": "bafy2bzacebtc3quqlhxuvkwfnspinwblcdc7o4rc5gsdjfytsbbyr4li73ymu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecs5rcqvjb66h6eoqkv4mwtfc5ziklk7css65wggys55k43l7vsmm"
+          },
+          {
+            "/": "bafy2bzacebpnz5hvfysibucklp3tevisbgc5zip6aoys7c3gsibtsqazq33oi"
+          },
+          {
+            "/": "bafy2bzacebf4rty3z7pf2bo7tmishz2zaatpdhzc6tgabtdhivnxwq2rlfvok"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919650,
+        "PowerTable": {
+          "/": "bafy2bzaceag6lzz3d6oixqy2dyhdtoxgpxfvm6uwe5o72mqxykidtpqv6vvfo"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebm7xei2ek42ywf6kfmiussurxpxmrqgucspjc4qdrnamsacj3kmc"
+          },
+          {
+            "/": "bafy2bzacebweoykmjyd5xhug6jyda6abmim6rewfw47iiockz37ewow5fkmpe"
+          },
+          {
+            "/": "bafy2bzacec7aqyx6kpqcrafzo4jqhsxtsudqq6r5ikxebqgxlffokbl7j5pfy"
+          },
+          {
+            "/": "bafy2bzaceaenvu5iwi7dhy5dclyp5ljjmrczbdpmxmpqpfcyfdvgsupu3vsss"
+          },
+          {
+            "/": "bafy2bzacedtqs4a7tru4l7k6iuhfflenvw6dwqwiyl7uxxnaqh25krqdlwq7i"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919651,
+        "PowerTable": {
+          "/": "bafy2bzaceb7k6dnmnqllggg5tf5qmuvybyb3gqxifs7i7afpddq5on2dtlg2w"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3gxpvn65rrqsmgkhleszigltdis67a5d4xowwgc2e2mds6alqy4"
+          },
+          {
+            "/": "bafy2bzacednwe72qi3jdhlaggtf6th4uhd7473y4zpxfs5o57em7gptlttff6"
+          },
+          {
+            "/": "bafy2bzacecleslwbtrbn4c5wsif2oasol6xcjokyi2eqjxxoptydj64tru74m"
+          },
+          {
+            "/": "bafy2bzacebjt5zciwyfa6ts3z46s3g26qy6phk4s4f5x5i5t3edmdcykxcsya"
+          },
+          {
+            "/": "bafy2bzacea7egd532np4ld3wbogu5gtm7u2qareymdu6gzasperfb7mqcwe46"
+          },
+          {
+            "/": "bafy2bzaceb5rv4ijfrkljmz2ha5aqyw3tshqphlfelk72wwqgclamtx3kztue"
+          },
+          {
+            "/": "bafy2bzaceayxisz6r5b3mpu3tjt4hzovt5i4pwiba3itpq3kybqkd6t4vqcnc"
+          },
+          {
+            "/": "bafy2bzacebt4lii2i6xjqhmsrgtq7bjj7kvjo73oryxeh2fxtrcynnfv4ikwq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919652,
+        "PowerTable": {
+          "/": "bafy2bzacebl5efmnfos2mbjmxy2kr6yvp5dgilvynclhuwu5ux2j4ry4ajani"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceajbzji67khziwll7irhr54mmxcxw33eucu3yr4r4pfumymwybyb4"
+          },
+          {
+            "/": "bafy2bzacecdzetw234bg77uvt6obgn3r6kvc5uzjx5m6phwtrfhygrndkhone"
+          },
+          {
+            "/": "bafy2bzacebdmdm66iibhbzluijlcefzbjiutu2wd3ttsdg6ua5gpaucfh2wlq"
+          },
+          {
+            "/": "bafy2bzaceajh6x5o46hnlg6az2ttqe6sdcc2b7tlcclr35b6dwshqnf55sb3i"
+          },
+          {
+            "/": "bafy2bzacealqgeflybsv3oakgclkjyigkanep7gv3pnh7a3yra22rzt43qxxc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919653,
+        "PowerTable": {
+          "/": "bafy2bzacebl5efmnfos2mbjmxy2kr6yvp5dgilvynclhuwu5ux2j4ry4ajani"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaagdukpm5towllitw5ny3wa3ipnrx7oxxmfkt7ixkhhozxjfbjd2"
+          },
+          {
+            "/": "bafy2bzaceanxlw5lpifq24xml7aifhfsuo3xo54wfk2rccuaeiq6fms23eeo6"
+          },
+          {
+            "/": "bafy2bzacecib62y3r43okato56l5fpmr4fq43usglfcuqn5bgk3kiq3msmbee"
+          },
+          {
+            "/": "bafy2bzaceajhyk5itx5oftmen7lfxkmjx5rhrhvfcjswksnthehmrypix6yjy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919654,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebhnv6lqk5zzipd5k3hq7xmnxwafa3nduk47vplr2rtpmbjs3c3kg"
+          },
+          {
+            "/": "bafy2bzacedael62ppv6cp6jjlpiev43yqgkenyry6yd2dbu74y22nmhwz7una"
+          },
+          {
+            "/": "bafy2bzaceali5drux2o5ffnzxdb57j3rejro6jc4urw2zh73vsshfb7vt35qa"
+          },
+          {
+            "/": "bafy2bzacece2fvmbc662tbexhznintpao4nwwdjbi6nn4cglre2fxpkoi2kjs"
+          },
+          {
+            "/": "bafy2bzacedx4so45bukwfaxe5s6czhogbk3ondgitwhutie6np7cbmnsnxydc"
+          },
+          {
+            "/": "bafy2bzacedq6hhm2ee3sapxknl2uzbhcoeqenhwizg7owjanqntyxvjxv6jiw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919655,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec2uuv2h5jy6t23p76j3kyneoooub6inlic52rt4hknzlclqjr4ki"
+          },
+          {
+            "/": "bafy2bzacebeig4jfhnarirurlrebqo6fq52kg6wucm7vbnmcan7ffjrrgflwg"
+          },
+          {
+            "/": "bafy2bzaceaae4hwbberp53pdnv7pycm3cl54jz5uwd4vlb2htyoioyypaetfs"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919656,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      2,
+      1,
+      2,
+      1,
+      9,
+      3,
+      1,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      5,
+      2,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      2,
+      4,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      5,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      9,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      2,
+      1,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      2,
+      4,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      2,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      2,
+      5,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      5,
+      1,
+      6,
+      1,
+      2,
+      3,
+      4,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      11,
+      2,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      2,
+      3,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      5,
+      3,
+      2,
+      2,
+      2,
+      1,
+      3,
+      3,
+      7,
+      2,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      3,
+      1,
+      8,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      4,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      2,
+      8,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      2,
+      2,
+      2
+    ],
+    "Signature": "hTCfCgkRUPcW7fqvvnY/Vi/j4NJSdgcfmfF4M1MdSC6XHOwTMer+IJBPSdTvj7KIEX5+HLQPoXIJk7qfzDdAZBk8JUN81rK0QSEtecnsApKVUR8bDQ5KNNoiWJdr3jsD",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 4,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec2uuv2h5jy6t23p76j3kyneoooub6inlic52rt4hknzlclqjr4ki"
+          },
+          {
+            "/": "bafy2bzacebeig4jfhnarirurlrebqo6fq52kg6wucm7vbnmcan7ffjrrgflwg"
+          },
+          {
+            "/": "bafy2bzaceaae4hwbberp53pdnv7pycm3cl54jz5uwd4vlb2htyoioyypaetfs"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919656,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebdnlpnb2bcwosorjvdre3szpjbnxwm7kjuukffiurukuoklcjnge"
+          },
+          {
+            "/": "bafy2bzacebl3gdg2ks66zfvqsh4plv5w75jglmnmeygzmyvr534w2m7ylozbi"
+          },
+          {
+            "/": "bafy2bzaceamg3yo7wllvfud3nqygjvcgx4ltiabujdrat264xiltxzvffwdao"
+          },
+          {
+            "/": "bafy2bzaceboaorm2bimbzk6kmusfyt3lx3tnda7xi4esmzcj5jau2ldikid7o"
+          },
+          {
+            "/": "bafy2bzaceczfac5k2h4alwl2ku26afsi6u5xnp2u3orv73ti53zbpdcc3rpui"
+          },
+          {
+            "/": "bafy2bzacebuedjw2vh6hx2eho3vu3juj2fuwk3zvidpyg4v7sgzthtvmichoy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919657,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea56y4dxd7f7znu4zdmm5xzy6kidgj3s3ydazwzjvagqirixjapzy"
+          },
+          {
+            "/": "bafy2bzaceczrttlb7apjqyis34gojnwespaitat3pvq45v6cle6bsubfy6ygo"
+          },
+          {
+            "/": "bafy2bzaced4eq6jr56flwitcsftj6psiuz6dds3pu6n76424e67ajeqxy44sq"
+          },
+          {
+            "/": "bafy2bzacecvjpt52tsn2iqc67kkjawic7ld6gnlqs23ipm5ezm4ln6l34xcwc"
+          },
+          {
+            "/": "bafy2bzacecsaxp4po2qk5hgpcxyhkymdqmrmuwxzskp7hkkk7262wsee3kpa6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919658,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedqvakocivnw2nx7i2vto56qlf6bx2ub76d4ored7qn7vcoopkkbc"
+          },
+          {
+            "/": "bafy2bzacecy44nkuwpfhnsa2szfoiljfmifnkdljvmbaxtqgnpytqsswaletw"
+          },
+          {
+            "/": "bafy2bzacedcaococgzuo6lr7tey5o6pvd37ypgeqzgbis3ouhv6ehmt3zfuec"
+          },
+          {
+            "/": "bafy2bzaceba45cs7btu3n7uwkt632nk5ve2plcwpyat23eya7kx4huezkbr4o"
+          },
+          {
+            "/": "bafy2bzacec3wmo75olj4r67y5ieisz3a6uq6vc7ztn65rgvroirh2zomsx2uu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919659,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebjivvpskdfomzopn3hgm4m4nkqsfrqau7clxpv5zdzzvyizado46"
+          },
+          {
+            "/": "bafy2bzaced5apg73tmgqmpxcgk6qcjdebdvksxcr4olfwdupdlvzenpzmmlny"
+          },
+          {
+            "/": "bafy2bzacea7h5yv7rejx44t3p5w7w2jobu7ibr4nuaf5bs4zdzce5m5zltlie"
+          },
+          {
+            "/": "bafy2bzaceaxu6zazi3yq3tltqhhkhmdwasbpdxj646c5zgxmezt63nvx75iwa"
+          },
+          {
+            "/": "bafy2bzacectyulewb7f7jmsoqnjtcr3ghbzeizsxxe27k6crxdvmo5mknctf6"
+          },
+          {
+            "/": "bafy2bzacecqn5u7x446mpz76hq75gzxa7finaus7gkf5ic7qw7ydx5bsdk4tu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919660,
+        "PowerTable": {
+          "/": "bafy2bzacedujgqmzas6miieu26nwcfut4nelkgwhkaz4skwcjq5ytod2jocb4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecitqef7griflrnopzwqq4s6wto3ykx3bn3ofhsngxjp5ov7g6y3k"
+          },
+          {
+            "/": "bafy2bzaceatnmgwhewv3jjhpsaya7qtpyry72wtnfwvfdk7pju5wtymvdhkxw"
+          },
+          {
+            "/": "bafy2bzaceck3v735mapfgaowofcbea3sye677hods67hvi2g3gxc4l3qu7vxy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919661,
+        "PowerTable": {
+          "/": "bafy2bzacedvvdxwn4yeyds3lb57yewbbtfjqwp36b7uafwac7nim3zfy5l7ry"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceckomjif3nzhskbplw4appsitds6npjdgebrmgzbcjagkzfmmetou"
+          },
+          {
+            "/": "bafy2bzacebuue7xxzqe2kxbgvhbq722tofy62ctk4hu3wfownprzwp65rnu5w"
+          },
+          {
+            "/": "bafy2bzacebyuyugk4svdno2wfosqc5kitjoiarn7w3ykmujhnlefl4xqwkmlm"
+          },
+          {
+            "/": "bafy2bzacebbugjnkwdr47angfpof4suazbc74r5gfrhdt42hkme7aehgowpvm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919662,
+        "PowerTable": {
+          "/": "bafy2bzacedvvdxwn4yeyds3lb57yewbbtfjqwp36b7uafwac7nim3zfy5l7ry"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebdlmlobzoszgcnl3ql3nkrnk65fmlvwgbzulyz4qrcogfdxhdmcw"
+          },
+          {
+            "/": "bafy2bzacecf7u62jhgl2qmfosa7fccuevifc5lukgixbxeuebis4atts6gx7o"
+          },
+          {
+            "/": "bafy2bzacecmnb22nolfwxs4qsq67kjpz5xhf5dzhviatn6wjggwuutpcuy2tm"
+          },
+          {
+            "/": "bafy2bzaceatkcu5gqbt5h6fwj7s4itiah66pbl6st3ftbv2d7lotb3yyujwj6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919663,
+        "PowerTable": {
+          "/": "bafy2bzacedvvdxwn4yeyds3lb57yewbbtfjqwp36b7uafwac7nim3zfy5l7ry"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec6sjcmtlp3nuqofgzyikyjup3y2jxga3izsje2l6wsn3k5hh6gtu"
+          },
+          {
+            "/": "bafy2bzacedfyn5ebe4mbserkd5y74rnnfvlur5ujqsvvalhfrfebmuwx3xkys"
+          },
+          {
+            "/": "bafy2bzaceb7ndd7lcc3e5cz333tmw5eeqlepv5emgc6i2iatnzcez3jw57ty4"
+          },
+          {
+            "/": "bafy2bzacecynjb5q5ooxwb6vrqwu2jascnadqvwaebddedbb7key55mwa7a6e"
+          },
+          {
+            "/": "bafy2bzacea7cegqua2z5pok2rmnmw6e6kmthrlfaoprd7cvha3ndmrroeq5lu"
+          },
+          {
+            "/": "bafy2bzacecawefn6lzvvv6gnf5wahs5nid675usiyokgwxcdztai73npkxvr6"
+          },
+          {
+            "/": "bafy2bzacea73c6rem7k3df5hxrup25wojqwdin7mys7fq5ogxdgooepcyrarg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919664,
+        "PowerTable": {
+          "/": "bafy2bzacecwifpjyorvlugbtxmtsoy3xx5ujxzzhxpdoaaldj3wds2cfiwi3e"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedlsfl5a3wzm7ewtuwnreysrpo6ibg64reh3uk4wy4elfq2qwew7k"
+          },
+          {
+            "/": "bafy2bzacebki6nkb6ctunmafpv66ai7bre4vgmaxv3ouzp6xo2pvdshkmsxeq"
+          },
+          {
+            "/": "bafy2bzaceaodgdsnzygyzn7dn3gx452elq3smmzmga7ra7p7vpqj2ecyole2c"
+          },
+          {
+            "/": "bafy2bzacebv3mpb6figlxvwbunvwped3obc4rclmblqatci2zbjx3qxwht3oy"
+          },
+          {
+            "/": "bafy2bzacebd2qlvs4amnz6lljyn2ocyvintqsyl3lkjpvd5v6d4xib23xohce"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919665,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced37ylfi2wjfaqtxb7w7n2hxgfunzef4o5emjght2q3anf6tefjom"
+          },
+          {
+            "/": "bafy2bzaceaigxizzdmb3bj5zqe3bo7664j25dmnut5uxqpuf5u6zqpkejpyfs"
+          },
+          {
+            "/": "bafy2bzacec6n52fylxgt45xkvnfv6mkyyf5dn5kyq4r3eeu4nttjvb4qvft7k"
+          },
+          {
+            "/": "bafy2bzacectz4txd7rxxv2zynjw566s7s63jo3rkgltbxkjpmamt7cm5uut42"
+          },
+          {
+            "/": "bafy2bzacebao5iovjamvzbpf73d6r3glnnwr52tjppcclpmceh5at3aztcece"
+          },
+          {
+            "/": "bafy2bzaced5sgc5ozy2ckbjxloow4rzfcac6mbggvurz6lxgo24ua3hsjf7i6"
+          },
+          {
+            "/": "bafy2bzacea7nyypimbd7y63xutqp75kfqlur4l25iutptbjv73fghq4d4xleg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919666,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecgwht2ripexq4ngrf7h3bz5hpniv2ul2mnhtgwn5fzj4va7wccfq"
+          },
+          {
+            "/": "bafy2bzaceauig2od2dav7sutnrwizrixilc3vtfoq5ajmdblnuiieytzifcca"
+          },
+          {
+            "/": "bafy2bzaceaztt76k33fd6qghcjdzrwvm3nxawc5qhp27o73e2y45aindp3y2g"
+          },
+          {
+            "/": "bafy2bzaceaegaik6rp7k37zmnnl6tn7q6upydqotswaxa2xjjpwfbkfutsaum"
+          },
+          {
+            "/": "bafy2bzaced24iis4zpufktb5qv7mg5tpxeqbapomqp6p6zgapegrcl6xomu4u"
+          },
+          {
+            "/": "bafy2bzacecils4b6u3aot2ckur62bwjmxhpquuaofeeg7d4pmzuuo3d6eyzx6"
+          },
+          {
+            "/": "bafy2bzacedkfvk62eav3jh7tc4bomeieihjg7pvcfut2buv24mtjrojzw2mgy"
+          },
+          {
+            "/": "bafy2bzaceddfpzux4v3r4eank46rtcoadeu7p7y2l4sywtktkc6h4kzheuylo"
+          },
+          {
+            "/": "bafy2bzacedv3gxdage4sf4vdyc4bdtx7f2sqc35pslk74t7mkq2gtnglmuzkc"
+          },
+          {
+            "/": "bafy2bzaced5wqz2xlt57al6a4mypl4v7zbnoyzf6ff2yrctubico7l6ozo23u"
+          },
+          {
+            "/": "bafy2bzaceb5bimjr7equ5xzbub67xvyavad64btv3dtnsgtbovsbfjdffdbfy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919667,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecbwkmufsmxx5vjv3tdmx37l6wtypuimd4faahvou22ybn5vlppps"
+          },
+          {
+            "/": "bafy2bzaceaqcxcjhktpaaryu4onrkpkllg45qpopwaiamefqcxkt2f7p7uhfm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919668,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaq2fft4v7lje6jhh3hpf6f7lzjpyjm3czibcutghp7qzumcbfzwk"
+          },
+          {
+            "/": "bafy2bzaceckh7vkih3moadpccunw3usj7ls2dc7aq52nrhemmppjrnb4vj66m"
+          },
+          {
+            "/": "bafy2bzacedwm244uayt7mxjso67vlon2hzqmngxw6mp6znl4nutrbnfk5zstw"
+          },
+          {
+            "/": "bafy2bzacedaffmv6gl55coai6wcfvclcqivxijfllumrf53m4vo2lrodggxue"
+          },
+          {
+            "/": "bafy2bzaceb72fg5cubsiwqi3hcvqwlmljnfv546bdmwtbjyu74fylnvunueea"
+          },
+          {
+            "/": "bafy2bzacedtqbpyveabceei25s7nval5r2tkmkxvue4exr5hb7wqvbshxpeju"
+          },
+          {
+            "/": "bafy2bzacea5otas2alubg4rwgk3qjs5fj7fyuvbsfy3wdecmaqwjj7jt3t2f4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919669,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedkbxef4cqbd5he66ls2a2d4lspmivwg5kwn5d6ix4kwd4hcvma42"
+          },
+          {
+            "/": "bafy2bzaceby64lpc3gw6nerq5w5shsnabpko5e6mchsn7qjgqnbv2ntkpov2q"
+          },
+          {
+            "/": "bafy2bzaced4brp357a5q2hvc7lwaoh3wnyvb6jac5rjz6zk4lqo3i5yyoycz4"
+          },
+          {
+            "/": "bafy2bzaceaql2k6d63dnvtmohjsfyyoz53h7ssgfm6nkng3yq7xmjlfrapdao"
+          },
+          {
+            "/": "bafy2bzaceanitsmuzki3jk25ntxby3b3plzgogsborcg7d7as6j66sfbrx522"
+          },
+          {
+            "/": "bafy2bzacedtvg35kty5an44ccg77if55w6yicpuzcrg3e6jtzzgadclgez2wc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919670,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedb325lpdyeexqonjqc2uhivbwvy7fyw7pybcwrprwlowvjypahie"
+          },
+          {
+            "/": "bafy2bzacedabjuqq43qkmk5dptmjy5gjz6yj63hyzrdvjki65fmofg234uakg"
+          },
+          {
+            "/": "bafy2bzaced2dqb7uoi2imb5ju5vtc6udm6besxzmdiy5t35cfodnb3acdctuy"
+          },
+          {
+            "/": "bafy2bzaceabees62dxstjhv3nvx7i7oi35bn4vlswk7uu5ho3qgjuqpogyhou"
+          },
+          {
+            "/": "bafy2bzaceak7hxpe557hqmb2frgv6m3kfl7sn633fmbs3i2ykxgctqh6tsoca"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919671,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedh2vavebbm4rzj562mxdeexqvfd2kinb47rftzleobf4sn6r42ee"
+          },
+          {
+            "/": "bafy2bzacecrvr4knl3hva3ywxk6yclimpjgzh5xufhc4q3przbjvbaf5vc4dg"
+          },
+          {
+            "/": "bafy2bzacecnducfj6dg6ixz3r7pj62fgafmcqrclylydvw6rz2s742yebwh4w"
+          },
+          {
+            "/": "bafy2bzaceb2i5ahp4wavq26bl6nyct6vhmoys64mt5hnv3ejbilpmam7rkdnw"
+          },
+          {
+            "/": "bafy2bzaceaasxdldlzp6e6uvpcleek5xvyysaw56kh2oqde3src7pjlmdyjg2"
+          },
+          {
+            "/": "bafy2bzacea3l6cfa3xssdcmpxdh3lmtzkbn5xrjzacu3tywzspulzua3ywvl6"
+          },
+          {
+            "/": "bafy2bzaceanef3xu2uqvesug54g7kcj6vcqhnx4rfmakd3xdmudi3lfd6ju2i"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919672,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecte5woq5qhk4wkzuxlfww6ve2wphvwrmg4uqtwn75ejhb5xvbigs"
+          },
+          {
+            "/": "bafy2bzacebt6me3cpxvdjccjcffrubcqfldn7z5kik4wz5m55kgulanzmmlvs"
+          },
+          {
+            "/": "bafy2bzacedqp7j4zzvmyghdakfiy4hkdcrfzuxrpjpzalhueg2bcdatmcb77e"
+          },
+          {
+            "/": "bafy2bzacecusdqy7u4b22ynclo4gssbie43dtiryuxvfxatqsy3kkyb4b4z6i"
+          },
+          {
+            "/": "bafy2bzacebt5463ubghby5m3fe2ko3dzjbw32mxnpmkbecr5lngvhwvxmp6rk"
+          },
+          {
+            "/": "bafy2bzaceb7xlgqzx5qakief6hooodrlc2amwonih7srqc2gexonccqvvltdq"
+          },
+          {
+            "/": "bafy2bzaceckrs5cjdecjcc2mmn5zmlh4kvctgjvh7mmhlnbw7m6hwxkxyrh2a"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919673,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceckcmtmu5zthq6mq7fq5m7vdxw2quamo22edkqtgenpwztkvaosic"
+          },
+          {
+            "/": "bafy2bzacecbjngpjzz53hra6uv4zaihx73xxlfn7kikp2mcq67mlznhgc7eik"
+          },
+          {
+            "/": "bafy2bzaceco7ivgnafn6otsimqde5ikxfqqcob4u33ac4sykgwcrdjeajztn6"
+          },
+          {
+            "/": "bafy2bzacebrwc7rv66atue4qv6khnedm5yuainnkdsxbjqc4axrna33u6wqmc"
+          },
+          {
+            "/": "bafy2bzacedwdwzta2tijuzsbl4322z3hk7x22irbi2wof6t4osby4mtszfbos"
+          },
+          {
+            "/": "bafy2bzacecwufaeqa7hltuvke35htx7f3mdjyps5y45n7dyzx2pwjciyh54su"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919674,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3wji3jumggh6afpswuwoiwvwdw565x6ycf63yemjqtztlqoyazk"
+          },
+          {
+            "/": "bafy2bzacealueyg3kwwydfp56u763tufygpfaqdrmagvg6vci73ss6m4ihs7o"
+          },
+          {
+            "/": "bafy2bzacedfuzlb2ccuxs7oftj3qnbc4b7kplb7sezspvjvyke5475hgy6wvi"
+          },
+          {
+            "/": "bafy2bzacecx3qeq5s327m53detomck7se667afobzabl2pnlry2sanwjkpptq"
+          },
+          {
+            "/": "bafy2bzacebah6edhlsvmndfgliivnkiq4cyhq6rkikjn6kjnkjknogv7o5gou"
+          },
+          {
+            "/": "bafy2bzacecvs3fmhxhkmvoimh746lvwwm5dzvwpcj6du4ouobwsit72ah6mnc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919675,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      2,
+      1,
+      2,
+      1,
+      9,
+      3,
+      1,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      6,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      2,
+      4,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      5,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      2,
+      1,
+      2,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      9,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      2,
+      2,
+      1,
+      1,
+      11,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      2,
+      1,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      2,
+      4,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      8,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      1,
+      10,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      2,
+      5,
+      2,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      5,
+      1,
+      6,
+      2,
+      1,
+      3,
+      4,
+      1,
+      5,
+      1,
+      2,
+      1,
+      1,
+      3,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      4,
+      2,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      1,
+      3,
+      2,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      2,
+      1,
+      2,
+      3,
+      2,
+      2,
+      2,
+      1,
+      4,
+      2,
+      7,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      1,
+      1,
+      4,
+      2,
+      5,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      2,
+      2,
+      8,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      2,
+      2,
+      7,
+      1,
+      2
+    ],
+    "Signature": "tFZCZAN7qPEv0y3Tbfxwxp+xgD5cXiIzeuVAhT74BVRRvoOhSZIbQ7dcfMWdUcauDfvYfU26k6g5gFA0Im0lfjnXH/dcm2wuZBBt917J0dgzxmK3BZcDUPZYe8NloovZ",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 5,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3wji3jumggh6afpswuwoiwvwdw565x6ycf63yemjqtztlqoyazk"
+          },
+          {
+            "/": "bafy2bzacealueyg3kwwydfp56u763tufygpfaqdrmagvg6vci73ss6m4ihs7o"
+          },
+          {
+            "/": "bafy2bzacedfuzlb2ccuxs7oftj3qnbc4b7kplb7sezspvjvyke5475hgy6wvi"
+          },
+          {
+            "/": "bafy2bzacecx3qeq5s327m53detomck7se667afobzabl2pnlry2sanwjkpptq"
+          },
+          {
+            "/": "bafy2bzacebah6edhlsvmndfgliivnkiq4cyhq6rkikjn6kjnkjknogv7o5gou"
+          },
+          {
+            "/": "bafy2bzacecvs3fmhxhkmvoimh746lvwwm5dzvwpcj6du4ouobwsit72ah6mnc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919675,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec4tvfa67y53iyg5ej4rhoesdfe67g3rygahfbdrszxzk6qwirlsm"
+          },
+          {
+            "/": "bafy2bzaceclp7wke4omq3kpimlyhcoujlunydhxssb2d4hmua2bau6hwdp4x6"
+          },
+          {
+            "/": "bafy2bzacecnnve3zaxoidw3vxiosoc6a5ehxyn4hvjcgic5soeulls62vyzvw"
+          },
+          {
+            "/": "bafy2bzaceak3y5xlvl2zs7mtvh6r5dhmnahhpyldlerdbam42x7hubkwtiwzg"
+          },
+          {
+            "/": "bafy2bzacecouxha4alz5ce7hozqv6bfh27fztaa4to3y4zccb2qbj4ijgsijs"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919676,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedz7fd5xs6o6mizeu6oodybkvlv5fgbptonhos74grn5v4hamzbhy"
+          },
+          {
+            "/": "bafy2bzacebqeue47a4e673fkeqoac7vhficwad4nuqrwenqty4b24goygs656"
+          },
+          {
+            "/": "bafy2bzacebhfq5hhtgiql5l56kvbgpsqmxinduzbidm2nwqafpg7l7bvlxk3k"
+          },
+          {
+            "/": "bafy2bzaced37wxsxedhmjsoa5lci2qufrneskwhirmxyq75e2illo6a3aq4gy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919677,
+        "PowerTable": {
+          "/": "bafy2bzacebkm7gydydngnuynr3lhxtlmnxbmn5jh6dg6tezqfyhow4xopa73g"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebli5uez2kysfswo4gtw4oyjixirroa64wt4kxfql5kl6tuhhn4us"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919678,
+        "PowerTable": {
+          "/": "bafy2bzacecve6za5ndgtkrqtysnybsqh3327uybywlcakhrtkrzig6lb25qj4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebn7u55jey4xlcirehqbpa5mdfal5osgytjpwkylmgyjfldsz234w"
+          },
+          {
+            "/": "bafy2bzacebuxtk3c6dhbrf6m2sx3sxhplha5tyyx4tmwgkcvoxuvdnoxjq5fe"
+          },
+          {
+            "/": "bafy2bzacedx5eyrkqf5o3kkx2hs7agghy55pmxafs27up76g6ol6jftsi3ldc"
+          },
+          {
+            "/": "bafy2bzacecyp3k6ynlp2rggvq65ko3fysuuphnlxdpjrvjzt42fa3hor57iws"
+          },
+          {
+            "/": "bafy2bzacecu7dwqskbksydaxyzfr2v3kglez3j7h7yzrcpejqyiu4dicsqalc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919679,
+        "PowerTable": {
+          "/": "bafy2bzaceaxmzfcoxtnknkhzy5bp32gyamqfmsronuifegozzizfxd4dwrad4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaslzmi5fjzzsww4gd2tplav65wy5qmfw6do4jo62njc4agxoms26"
+          },
+          {
+            "/": "bafy2bzaceaf3j4apag3dmo2fnuxrinzx2muk3uhu3fgxkqardtz67y4o2fzho"
+          },
+          {
+            "/": "bafy2bzacedxrnuru66hgakmzogcfr6cqbjnuzbupu7bjmjeftfboowmvthnxc"
+          },
+          {
+            "/": "bafy2bzacec7fb32ihe5qvcpoglw77dltxcosbydgap6enaiucesbygomvyjfc"
+          },
+          {
+            "/": "bafy2bzacebdsdv3z3kzh7x4ws2odhcsxyy57xxcqrves4h6s5qrmpqawyblio"
+          },
+          {
+            "/": "bafy2bzacec3v5tzwzqj55k4bmqledf2x37posj7vdihjfulxibqtf6bm45wku"
+          },
+          {
+            "/": "bafy2bzacealvur4d3jrlhn32zrs5664qlljb7dn5a6erhompfnzsunpxxjstk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919680,
+        "PowerTable": {
+          "/": "bafy2bzaceaxmzfcoxtnknkhzy5bp32gyamqfmsronuifegozzizfxd4dwrad4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedaxj27lfwaab2c5nmgfjogjx7hpy63v2l73rtbwworyzhzzmzlvm"
+          },
+          {
+            "/": "bafy2bzaceahaal34rs3h2jnlfolydbp5gg2dhr2rwut73c25pg2qc3aqmyg32"
+          },
+          {
+            "/": "bafy2bzacedlel3axzh4x4sbm3d37fmez3zwlkldj4epzs2oemi3thof2ykt6y"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919681,
+        "PowerTable": {
+          "/": "bafy2bzacebvj7777w4nmj6tbcjvyr7yhkewxdsx6ggem6icwqd37jlbjthw3o"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea4lxkvxjqgml5ohkmx4q242narmbb6y4rcnkww4apbskiczavyeq"
+          },
+          {
+            "/": "bafy2bzaceb2kgylyqi24gfuibxtdjxmskvzgo6esb2cydntox4z26wa7zbgzm"
+          },
+          {
+            "/": "bafy2bzacec7efusj5mkrj2rgw7ds4p2mkqegf46kpihmx4y4g77fb3fvtrufq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919682,
+        "PowerTable": {
+          "/": "bafy2bzacedd6bicm67djrumrhr33gumpqm637mhzzhombyyzrfzymczrylj32"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced4q2tfoxi5nw3grhqirmatvtzow7m3p25bdnrrbgrehailcnhaqg"
+          },
+          {
+            "/": "bafy2bzaceajgacbot6v5pficfp76z6qjkaqztpwqvxmcu3m35oa7zgbnsi4pi"
+          },
+          {
+            "/": "bafy2bzaced4czxjweqztnfaxyp46urzhf5cym3vvls32wpayl4x4uxgttiqdq"
+          },
+          {
+            "/": "bafy2bzaceby73c646rkkksaapkdlunro7ojokedrnmddctq37hekazkfbk6wg"
+          },
+          {
+            "/": "bafy2bzacedlgnncm27fvyqd67z4gx37qu34netcsbvezy2xl4rhqzltpryvxe"
+          },
+          {
+            "/": "bafy2bzaced6n655zlglhospsgpqsdnex26k5w2zctp2z4jbygepvi7cs52qzu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919683,
+        "PowerTable": {
+          "/": "bafy2bzacec2ugt6kg5rdrte66ijhtskywaxyrmg2urrsysip6aso4o3tg5iti"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebmge4ip76mlwpq7omkgqegrzv4u4cfeeaguqjcrqtypjszqhsima"
+          },
+          {
+            "/": "bafy2bzacec24wxbmhitfxwizbf3x7pwgnlrdfdlyxtdgvk74b3zjsfsjiqkya"
+          },
+          {
+            "/": "bafy2bzacechmbpiuo2eeicb5rftuztb4phddfhf5dapjc5xdbt5ttesoenonw"
+          },
+          {
+            "/": "bafy2bzaceaowhhz27hdfushpjrsjqsgo5wme3umgz4fxhkwcr3gq3r7gkkfuy"
+          },
+          {
+            "/": "bafy2bzacea6hwdaiobstcr5fednhaglpbyqin6idoimp6wgpzkqdeotq4e3gq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919684,
+        "PowerTable": {
+          "/": "bafy2bzaceawmunxsbpnsngt5cmm4yc54f3cig2rjviqggoe4o4vc7syurywb2"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec7e3k67qmaokgckgprp6oup5snlrz2qzqj2c2zgutaflerffuika"
+          },
+          {
+            "/": "bafy2bzacebfedldv2pfo5pn2a6wxfk2wwpvj7orhm6uops2tfawmhzoetachm"
+          },
+          {
+            "/": "bafy2bzaceai7ro6rlj32z6i32gcno5sccbsemuesfhrm4xch3vq7ukwpbpu4u"
+          },
+          {
+            "/": "bafy2bzacebfdhdpmmdvlljzhgykvnlxiua7dctyeieowqkm4hwfwaxx5mfofq"
+          },
+          {
+            "/": "bafy2bzacebmkrfiyvmk2tzkvynvggmyxlblep4wkghkenegmqho577barzcn2"
+          },
+          {
+            "/": "bafy2bzacecv4dznfvr2yv7r5256jyoqn6ndjfwkcssff5hvmnt3tn3jebvglk"
+          },
+          {
+            "/": "bafy2bzaceb4ftsblvog7y4k4cdtwg536gsgnrtiumujjc7jf57nqk7ubovv3c"
+          },
+          {
+            "/": "bafy2bzacebpb2zxmid5rdmeaiaddgm3cr6trqhl3vaxmnewqkvhqsdm5yq6cc"
+          },
+          {
+            "/": "bafy2bzacebu5zjrcib27rxeydkne4kjvuvgb3r75ovg2bafm57f25nlg7wtgq"
+          },
+          {
+            "/": "bafy2bzaceazi4wtq4e6x3zc3acqgdce6iisjdxbpdmzphuv4cu42ug2uvck26"
+          },
+          {
+            "/": "bafy2bzacea25qv3vozkxijovw7kpler2ubrppec2eq3xz6apotkt5aovp55fm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919685,
+        "PowerTable": {
+          "/": "bafy2bzacedzkphaarkv3ju5ggoiebehimd2qwqoilmakabuedmcy32dy6ybyc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceckpyunftnbwy4w5tgkqrpk53ybaifhvec553iliaebxrivkdpnkm"
+          },
+          {
+            "/": "bafy2bzacebjzmb52bpcolgrlwqph4qemnej45n2bjynzqiy37cswokvr3zbgs"
+          },
+          {
+            "/": "bafy2bzacecjp7ygnmatb3kai2djlwhkfifeknxpkuwon5gggffoy252h7vxy2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919686,
+        "PowerTable": {
+          "/": "bafy2bzacedzkphaarkv3ju5ggoiebehimd2qwqoilmakabuedmcy32dy6ybyc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecc35rk7627vbblenkcodepj5xo66wby3m7ya4dxpt42bxgn6f6hs"
+          },
+          {
+            "/": "bafy2bzacecbplyc7gr6zrruug5vsyqo5ixbqzn4w6a3kwucflkfjfwd7urpm6"
+          },
+          {
+            "/": "bafy2bzaceb4jfrtv3ku5d4hu6ew7kybwjp42lhdu7rcuge6lgl4okrlrtb6u6"
+          },
+          {
+            "/": "bafy2bzaceauhfpeunmnqnk37p65rihfp56ubgr4mhdm5zbgnuypbw7rbfvqzq"
+          },
+          {
+            "/": "bafy2bzacedy4mw363td2er2yt2epgp5gpcp3mqrjdujkgmszkswqjocp5a5pe"
+          },
+          {
+            "/": "bafy2bzacecffotj2zzd64figmv7jmdvu6jgxtgtxgz3kdgbzmckv5tmue3mvg"
+          },
+          {
+            "/": "bafy2bzacea5k6e6df5oi42uvmwj2vkjmaocyhbeoxwwbdxi4bhk55wfu57z6u"
+          },
+          {
+            "/": "bafy2bzacec6ep4zvno7pdibiakgijmepsqoovsghvnxqtqajh5te7yx6exj3o"
+          },
+          {
+            "/": "bafy2bzacedebot4kuujff6yfwkdkod3g4qhojdhcwccyrv64cy7fthtgewjbe"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919687,
+        "PowerTable": {
+          "/": "bafy2bzacedzkphaarkv3ju5ggoiebehimd2qwqoilmakabuedmcy32dy6ybyc"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceahvfi3hmek7dhyw2j6egz2uolhxzldqklz5hii3cxx4i5737tngi"
+          },
+          {
+            "/": "bafy2bzacea7mz4kytgsxbirgcdihequ7jzv7xqjesqm24brwp6tke2bj2i33c"
+          },
+          {
+            "/": "bafy2bzaceaapalv4xrt24tgtw2alw3nlup55ikcomwjc5oq46pj542zez64a4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919688,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedzbl6op6swst6npzabfjke2ett5k26khiwggdx3b2qh6cpukupdg"
+          },
+          {
+            "/": "bafy2bzacedg4tdmohvcno2lrxnygpnt5r7dpuoxd42knirgceujqvi2pwjkng"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919689,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebjw5ptfnrpohcbrhqbam4yuoebm3kyt2grfglkthsdea5dalzjmw"
+          },
+          {
+            "/": "bafy2bzacecddiillpyqh65tq6nj53lddcqwi3cn66xq23tlxpcebi2rbegbbu"
+          },
+          {
+            "/": "bafy2bzacebu4sw2d55acsjlou4h55c2lfmoqq24oxjoojsc24oflj5pwb2ntc"
+          },
+          {
+            "/": "bafy2bzacearxc4lrvoznhknhomliudnwpeqg64jddy5iyxlfscdlhynyzaduu"
+          },
+          {
+            "/": "bafy2bzaceaouurm3qr7zhhv6j56foyyegspxv7ls6ikwlrtvc7x5elllp45wg"
+          },
+          {
+            "/": "bafy2bzacedjqo4j2rdda2khaww7mp2rsgfoqyaj23rnvy5g7gvcvef342ehbo"
+          },
+          {
+            "/": "bafy2bzacecg57dwibzjdtr2heoposudfpwxpi4yeplfrxhhh23mdkkcxlsq3i"
+          },
+          {
+            "/": "bafy2bzaceay3c5t4qtkqbkdwuiqhoswbpbgwnaom77zhqo4rynbru3paesaes"
+          },
+          {
+            "/": "bafy2bzacecovb3t2rxykeqvmv3i66qjoao37zpnuubw2z47wj35bmlxmsiadu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919690,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceahi2lfn5bjzjarrxc5jrjv3lipjvnkixwd2mogdova6xbggayx3o"
+          },
+          {
+            "/": "bafy2bzaceae5qn3wbdrkuwya2oek2yqf4kl6arn7zfkcnbvztsbsav4yracqq"
+          },
+          {
+            "/": "bafy2bzacebna2hb5yjc6cb7jgpil4pocarwr5mar4zibpih764w24uvzjf4uw"
+          },
+          {
+            "/": "bafy2bzacedkeardek3ycnbdpngvqbcu3qqxgl473qubm5zao4pq554sugufpg"
+          },
+          {
+            "/": "bafy2bzaceduke6grojfbxlm4jwfapfhwra4zun6y42jvbwohwvxwcjji62us4"
+          },
+          {
+            "/": "bafy2bzaceb45ayw2aydu4rkcicnl5xrwif7p7tfuukazmpgogseq7fj352tpw"
+          },
+          {
+            "/": "bafy2bzacebyta45lceljpa74le7vbtf4trdk5x7u5gfo7jetxmrhjt5fz35he"
+          },
+          {
+            "/": "bafy2bzacedkqxrlhwgoey7yxyzipoc7tgcgilc7eqxwrdomyu3lau4g4g6rc2"
+          },
+          {
+            "/": "bafy2bzacebbwlmnzyev5tnsqg763yswar6sk4cg7ds3fuuwhhmut5uy6btty6"
+          },
+          {
+            "/": "bafy2bzacecx7jfbw7hzjt26ih6ljjtlu2xznwebsv27hmwwurcr5fbf4pte4m"
+          },
+          {
+            "/": "bafy2bzaceddqcvdgf6jflbv46cvtys3axsd7zmeuabt3v4ipylrsc6gcepkkc"
+          },
+          {
+            "/": "bafy2bzacedyt7vluhkivoj2jv376vwxrb6jzledy2xyfczrj5cevyp5d6nvao"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919691,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecakhvacjkvqjlohfthyszkppx5dycjhwl6b4ywd5oc3hsisqhlzi"
+          },
+          {
+            "/": "bafy2bzacebzmcarthe6rrgb6pvwcxjldhnml34axtjjla3cc5hpx4g45qcqru"
+          },
+          {
+            "/": "bafy2bzaceatyc6pfos6zuywasvgus34e4jhqqgszk6xd4n5dyk2a3xlnvhdve"
+          },
+          {
+            "/": "bafy2bzacec3yq4dgifelozjvgubrqyrmbzkkh24evsvm3qh4jmevp62hm7ppq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919692,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedeytheqrpqyyiapnebsucsfd6z23cgkli3b4qaatwpyhd42tww7q"
+          },
+          {
+            "/": "bafy2bzacec6xdppgvsyql5xx4x3t4zstxtrvojwukpoayefwh7dwqror77l3w"
+          },
+          {
+            "/": "bafy2bzacebmsraav6tijdeqpathj37vbayefb2xv5dlggymrd34jztxapschq"
+          },
+          {
+            "/": "bafy2bzacebg4n5vhjtmocxt6jbdfv2esm4u7fw3zsokxzhxx7ixtfao4eonb2"
+          },
+          {
+            "/": "bafy2bzacea36yrcgouhogxyj6p2aa2cgvqorb2vtiorwlygyh3wmx7anryyb4"
+          },
+          {
+            "/": "bafy2bzacedbnizskfu5br7it3pxx52we65ewylhjj2zdktgcdeglkvivjp3pk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919693,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebf5523b7c36h4zd6bvhur3zui2v5sityu6qxyjjlvj4ewia2jfv6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919694,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      2,
+      1,
+      2,
+      1,
+      9,
+      3,
+      1,
+      3,
+      4,
+      1,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      6,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      6,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      5,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      3,
+      2,
+      2,
+      4,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      2,
+      1,
+      2,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      3,
+      2,
+      1,
+      3,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      14,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      10,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      1,
+      7,
+      1,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      1,
+      1,
+      4,
+      2,
+      5,
+      1,
+      10,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      3,
+      3,
+      1,
+      3,
+      2,
+      4,
+      1,
+      2,
+      4,
+      1,
+      3,
+      3,
+      1,
+      16,
+      1,
+      3,
+      1,
+      1,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      8,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      9,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      2,
+      5,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      5,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      1,
+      4,
+      1,
+      11,
+      2,
+      2,
+      1,
+      2,
+      1,
+      5,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      1,
+      5,
+      2,
+      2,
+      2,
+      2,
+      1,
+      3,
+      2,
+      3,
+      1,
+      9,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      2,
+      1,
+      2,
+      10,
+      1,
+      3,
+      3,
+      1,
+      2,
+      1,
+      2,
+      4,
+      2,
+      7,
+      2,
+      1,
+      1,
+      5,
+      2,
+      1,
+      1,
+      4,
+      2,
+      5,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      9,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      5,
+      1,
+      2,
+      8,
+      4,
+      5,
+      1,
+      5,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      12,
+      1,
+      3,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      2,
+      1,
+      3,
+      1,
+      7,
+      1,
+      1
+    ],
+    "Signature": "ucce+L4EY0jCJKHkbT6BGLUIV6ggTwoNRW5bVbL4dpdQwXJfFY/EbPzrdfA7HB/7A0T9liT0IJ7dGjdTcxZQIirKOdOleqv/ZFr5I5k/41BM7Hw9+0R34qj/NxJYAPdx",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 6,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebf5523b7c36h4zd6bvhur3zui2v5sityu6qxyjjlvj4ewia2jfv6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919694,
+        "PowerTable": {
+          "/": "bafy2bzaceayzilffdpdhicmhjujgvw6ea2orvetgzyvgf76brjzvxjfn6ckw6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceai5qwvjsnay7p5ufb2u7yergeibj3xgzykhef6jh6ra6wl2gceuo"
+          },
+          {
+            "/": "bafy2bzaceanoihosbtye3c7yttk7rchtq4jcasbzllkc5tweawdakfysdlydi"
+          },
+          {
+            "/": "bafy2bzacec3kjrwopbqeoou4ijvowlxrdd52e2kr7bjwgbgbtrvy3d2azrkdy"
+          },
+          {
+            "/": "bafy2bzacedfb2jvmb5snip4pzuxqx2n7zlo5vgbsljpj2zirg5qubdeujarlc"
+          },
+          {
+            "/": "bafy2bzaced6x2ce3k22hkjpx2wx5nj6lv5wzgubfds7qnhml253m7d7wats36"
+          },
+          {
+            "/": "bafy2bzacedxidu7rxaldczfastqo5gzd56hxqj4a35wdl2aboz6hupam5iqee"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919695,
+        "PowerTable": {
+          "/": "bafy2bzacedmiqskmkqghf27wtbvoy4yp7g2ea6eu42j7c6dce6hbb5bd73hzm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebnyfxdlvrie4vbob6it5xdrd3ltxlzc3t6gsfpilid6b6f4qxhyw"
+          },
+          {
+            "/": "bafy2bzaceag4flluulcgm7ww5zd4vq4qlnldrqok6epiayppi46tgjt7by2ti"
+          },
+          {
+            "/": "bafy2bzacecklsec2ikt65tpmmjvqabs2ca35yw4ndme2dzm4n36ujadz5kol2"
+          },
+          {
+            "/": "bafy2bzacecz5hlatuxykiakxzfvczeo3mladswxylxkbmjxdvvyr23ni7s7aq"
+          },
+          {
+            "/": "bafy2bzacebn3twuwf4zqgbbhtczrcpddh6gdnya7huada7vqpr4wganhrps7s"
+          },
+          {
+            "/": "bafy2bzaceduj6zeygwwl2u5vdmhpoqqavp4diaktc2bitfee54k4slhsa2geg"
+          },
+          {
+            "/": "bafy2bzaceclreit2uijx5zcetbrdxicngoar2lhzubrlytozqbi3h22ifshqo"
+          },
+          {
+            "/": "bafy2bzacebbnjnl2yasgaqdv3zes6ruej4plh7dgspor5s2mdgfvtxwoz74gc"
+          },
+          {
+            "/": "bafy2bzacedqffmdlv6a5blxg72d4rru7prkqsidjpfl2fzuvzgndbqd26geau"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919696,
+        "PowerTable": {
+          "/": "bafy2bzacedmiqskmkqghf27wtbvoy4yp7g2ea6eu42j7c6dce6hbb5bd73hzm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecyzvtzjb546ddwbjouiemus3vp35mujbf44xo7r6hkfonwhl27uy"
+          },
+          {
+            "/": "bafy2bzacedsokqrgo7y3pbk72k7e7w73kbzagmlm6bbodju7ylkabayymbpqk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919697,
+        "PowerTable": {
+          "/": "bafy2bzacedixfhj4h4ay5jo7kbbfhjn6ob77mfhlmoxlrj3xwtd7ml5rzqbbg"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaagi7zgqb2tvyj6bush6ju2vq47g2vbyc77vjm2jgatmsgwkqqma"
+          },
+          {
+            "/": "bafy2bzacedh3i3n2aepyjtt47o3nawov42vo3jg43d6glpbt6anskjhuitge4"
+          },
+          {
+            "/": "bafy2bzaceamifi2fe37yuud6ia5bstywhb4rid52ddn5bgltehfrvhh2d446w"
+          },
+          {
+            "/": "bafy2bzaceat3bjf5rqf34ewsthl46luzf7ispwzioloctiqyv5f7zyinnaars"
+          },
+          {
+            "/": "bafy2bzaceb53f5x3b4u6iea4pv7ljojaefh2f3kr7cvisyym3uxca4eyq2mxo"
+          },
+          {
+            "/": "bafy2bzaceapygtqaforer5g5xyqih3fkd3myqipi7kf6ncvmrwm2fhpx2szcq"
+          },
+          {
+            "/": "bafy2bzacedo6j65zuacpxcs62wuukpezviergv6drsdufx7a5d6q6nbi3ayl2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919698,
+        "PowerTable": {
+          "/": "bafy2bzaceb2nqlqub3xndvptknec2nipyockyofawtw6hp5ojd2whegitbk3c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceby233iveymgmubgnp2gndgr7cv5mob2w3ktb6omflipraqjxxe4o"
+          },
+          {
+            "/": "bafy2bzacebms7qlmw46r6ryna5rtfbyobiw5b27z2q44th5733xixtaqfx5xc"
+          },
+          {
+            "/": "bafy2bzacebn7e5ne57qnxw3l6vhmgj4pmekhkviygzplwjeshvsv7tbmbmgq4"
+          },
+          {
+            "/": "bafy2bzaceatbmbk5ef3mtvw23ic2yre3p2kfog6byo73t735jendlbse2h74e"
+          },
+          {
+            "/": "bafy2bzacedknq75jvtc5fx7jbxcwlhewybwp5bofnr3kvgyad7ymg6avjh76g"
+          },
+          {
+            "/": "bafy2bzacecccdjuvgposz7cgd6iqmlzuh44rplmhh4zumboi6zdo3asryq3si"
+          },
+          {
+            "/": "bafy2bzacecvsrmzsixc7ys7kqws7ey3prgya7mmy7aokydisi5ybkbwxl66qq"
+          },
+          {
+            "/": "bafy2bzacea3keujsi3gnlq7d57aozrilicozm2ethuzm5zit4qeqvwhlrs74e"
+          },
+          {
+            "/": "bafy2bzaceam2pjsoue2ky7y5zbr324swoc66j4df2n3744677dbvw54ahs4ik"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919699,
+        "PowerTable": {
+          "/": "bafy2bzaceai6sk4isyiwfta2iwhndobodo4anjudwul42dgwqhujhykqgzggo"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb4t5ftpferhkzjmbfs42rsyctvrigu4c22grcvyucoefbbpbsvxs"
+          },
+          {
+            "/": "bafy2bzacedvjaihycoltebcauuvzefmevledgpxu4fb63rzolwxsvt65tv7fc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919700,
+        "PowerTable": {
+          "/": "bafy2bzaceai6sk4isyiwfta2iwhndobodo4anjudwul42dgwqhujhykqgzggo"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecs2r6lfe2pfzwkrzku7sjvr565x4p3tfs235hwk7smu2eqaxppmc"
+          },
+          {
+            "/": "bafy2bzaceac2mgw5n2odaojzkvgjlvqkyy56vuyxhypjg5qzqc5wqn6vpljxs"
+          },
+          {
+            "/": "bafy2bzacebjgdedzxjhe2wlmxbodkoobb43uxmccssy7ax5ci737qg43cnhvm"
+          },
+          {
+            "/": "bafy2bzaced65jyqk7qdcxiltm24lewmq3aoyw5oiot6fmvmnfftpku3zq4loy"
+          },
+          {
+            "/": "bafy2bzaceb35wsfph4fn5d67k64hx6sqqvnadxzdfvr2ykcul5xxmevf72f7m"
+          },
+          {
+            "/": "bafy2bzacedo3crpnnw57gqp6i6caukl5u2vyhwuo2ceu6vo5iqj2jcncu4nyy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919701,
+        "PowerTable": {
+          "/": "bafy2bzaceai6sk4isyiwfta2iwhndobodo4anjudwul42dgwqhujhykqgzggo"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebukusiknxskyknr56ysf22cgqlzghdshdxrxx3j67mixl2zoy6s2"
+          },
+          {
+            "/": "bafy2bzacebdsfv4omfc62g3yoyingdvcdp3ww46rygv7sqmqwanz5hxxt2obe"
+          },
+          {
+            "/": "bafy2bzacedhzi7l2mry6xbhv4kisxi7bt7ap43onjphc6rf7mmtm7mwr2lb64"
+          },
+          {
+            "/": "bafy2bzacecunkzflcdlhk6ufi2ggvwn262fuw3zo7sy4gx5hs53egbn7xcebk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919702,
+        "PowerTable": {
+          "/": "bafy2bzaceai6sk4isyiwfta2iwhndobodo4anjudwul42dgwqhujhykqgzggo"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecowutyex26ibz4knjp3cqtem623xmwcfjga7o3lmbkzxbiftl56m"
+          },
+          {
+            "/": "bafy2bzaced3p7ww2shumw643dnig7nlhdyt4lvswqapyz3j4atzkpnjiqscsi"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919703,
+        "PowerTable": {
+          "/": "bafy2bzaced57pum5ahfztv2amcbz3tdvks3xc5a3iy4kdj3kirzqyvzjzc64m"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedw76qevzdwdhfpogxlq5frjo43564grhmxjsvwbqinfr562f4rte"
+          },
+          {
+            "/": "bafy2bzacecbzak3olalzch3a437fbhatpuf2dgmepgjwv3pi4xdz77u3h66h2"
+          },
+          {
+            "/": "bafy2bzaceaixsmwsl6i4pfxrr2c23mruh2fwgbgzhw3fa47ahyjtgnsey7ono"
+          },
+          {
+            "/": "bafy2bzacebqb42nl2irf4uydto6nzuwa5ysjwmjmgydzwftzkkvkviwqw24la"
+          },
+          {
+            "/": "bafy2bzacecwlepjiqynf2m5kokofpzqfi2afr7wqoipgjumhicto42qzkngzo"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919704,
+        "PowerTable": {
+          "/": "bafy2bzaced57pum5ahfztv2amcbz3tdvks3xc5a3iy4kdj3kirzqyvzjzc64m"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceczrrfp52ql2rni3nztq4yx75jfgypazdzyr6stk2vs6txth5j4s4"
+          },
+          {
+            "/": "bafy2bzacec3dzqbc42cl4kwlt6vnuesf7cjt6hkqokih6hlhr6xewsqofjpzu"
+          },
+          {
+            "/": "bafy2bzacebgsetz7dfxjfvtosexkva4wxk7xe4t5mlzzu22mztp3argw6x4h6"
+          },
+          {
+            "/": "bafy2bzacect6vuphgowrqzyipupiw4f5h3764luez2pmpmzjbduiuxdr2ck6c"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919705,
+        "PowerTable": {
+          "/": "bafy2bzacedlfylwpyuc6kulezqwbrswcvrzncgtolmr4eavxry4niooij2lqa"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecp5eh52etbxkxhgliodiuzicgqokpvtviespqodnz2xdq5wm4q2k"
+          },
+          {
+            "/": "bafy2bzacecoxyruwl63vtwqjjooidvxuuwq5kksaexc6p77o4klmy7krkqaqw"
+          },
+          {
+            "/": "bafy2bzacecrq6yftzsv6jkmn5x72iw2m7r43yxpu2txjw3gcmz7uszgrr2f5c"
+          },
+          {
+            "/": "bafy2bzacebllfygup4oaa5c4nhxn354zzedkryowmeu2rc2nv23p5m6v7jvkm"
+          },
+          {
+            "/": "bafy2bzacea7ot53piults7zq3ln3arem6h5glbdie4y6y27qmnumhtxtx4nca"
+          },
+          {
+            "/": "bafy2bzacebwrs6ghgsdmkxtg5tj3yc2ryd3i2knlv5flam2fzq6asaxzielja"
+          },
+          {
+            "/": "bafy2bzacebuct45hlpras6e7luz7ihqp67yjznjtltpafcjklyadywpqcx3lu"
+          },
+          {
+            "/": "bafy2bzacedcea3rv4rkftsi5cyalvslo2rcw2bb2knpcrisxu45cuwkaw7jsu"
+          },
+          {
+            "/": "bafy2bzaceci2ml52jko2y5aje4jprjfhcx7exbmsccpjpm7fhihfpgsivggek"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919706,
+        "PowerTable": {
+          "/": "bafy2bzaceaskddpylpazakl5xkbrklpsy5vlm2kdte2zsah6janpa45h6gcqg"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedpkyg7mcfgtphx7sgoclprkf3qpwtfeofxnqx5iu2cmmzmxpbttq"
+          },
+          {
+            "/": "bafy2bzaceaca24a5lu75ooj5sa5eea6h4n33xvmlyquv3ujr3fz632krxhhcw"
+          },
+          {
+            "/": "bafy2bzaced3zzlf236ybykbfsckyxyyjbv4qktdjujk5qeshlg77w7mjf54vs"
+          },
+          {
+            "/": "bafy2bzacebldcwp6p4dm5v4kd2jqnbumiwy2zbdjb47bi22m4dgwuoogo2ouw"
+          },
+          {
+            "/": "bafy2bzacedmvrwlcqgywfytan64cus6y5ue3dkrhei6j3ry7vxdl672bqg464"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919707,
+        "PowerTable": {
+          "/": "bafy2bzacedsekgg3l62pyfinbnqmejebpevkeaesk5ds2hjhishmilk2oakbm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceapyam76lca45guast7zlwnjldu4yb3qngwcl5r5w7rjm5ttcqpiq"
+          },
+          {
+            "/": "bafy2bzaced23e7er6qmdfawscwysdallnbpisyiicg2iudj5pb7e7g5fojwqs"
+          },
+          {
+            "/": "bafy2bzacedo4ihtb73tniwcicd3wpq4xpv4w3aknl5l7xgnrf7m7543tbxmay"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919708,
+        "PowerTable": {
+          "/": "bafy2bzacedsekgg3l62pyfinbnqmejebpevkeaesk5ds2hjhishmilk2oakbm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebokggnq7o3lhfq7olvyy3h5y3pwxyqob6kcxhsus4ft4b4qamhlc"
+          },
+          {
+            "/": "bafy2bzaceb4hycxmus4einzssrmbabvdefo7cw5reodnghgzafucvciknvznc"
+          },
+          {
+            "/": "bafy2bzacecnuqhom46ylmo32fo7rh4lpscue2yl7md5mzpyf2z7lrqrlciruu"
+          },
+          {
+            "/": "bafy2bzacebyrtivqfk55mo6fyrwfxcoak7apzmfmcp5nmypmlhgkphumahmr2"
+          },
+          {
+            "/": "bafy2bzacedtpbhf2pyxye3pckc62lhlpz7nzubs73bo7lzar6k5fttbb5ja6q"
+          },
+          {
+            "/": "bafy2bzaceavc2wfltatos4d2oycekhygucezvcgrp522nvjynghdq6bohp5ta"
+          },
+          {
+            "/": "bafy2bzacebzkt5zzvt3vdqaf7uvfa2nvyqgo3kly7cuiknzarultvzvn5a36s"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919709,
+        "PowerTable": {
+          "/": "bafy2bzacedsekgg3l62pyfinbnqmejebpevkeaesk5ds2hjhishmilk2oakbm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedfsx6rmgq6kbvndbhvirlmey3zzuefaujkmfgmnf4a4wbhc2qmyi"
+          },
+          {
+            "/": "bafy2bzaceavyymtiawmk5ext4nnswosc6tuwfndyyrbv7z2ryte75g6ed3wws"
+          },
+          {
+            "/": "bafy2bzacebpwy7dbin56w3cxdxlixc5dd6wqqhe7avo66gnjq6vlkhdwzhlti"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919710,
+        "PowerTable": {
+          "/": "bafy2bzacebd42hfqx5kgx2z22wo5xqcopc6bamdrz677zzoyn7sm35d6qn5hu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedvxffsgpjkoeof2azd7qpdwggffjambqu55eno2aowrolfu32tp2"
+          },
+          {
+            "/": "bafy2bzacedbwsjj2mjqbvdduomusmrh5ptlnvoviyarjmnofhuteguxbfmcqw"
+          },
+          {
+            "/": "bafy2bzaceauism6kzrdqgshl42wx7gljolbdrzbj7i323nqihvo4gw7q6rgty"
+          },
+          {
+            "/": "bafy2bzacec5wn22wv42jnbs34p2hepixh7h4itm7hk425zqznwszxp47sd5yk"
+          },
+          {
+            "/": "bafy2bzacecucq6fkgy5b5xi6ygyn6qe6vhyljf6qvj665rcnel4vazrpywk22"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919711,
+        "PowerTable": {
+          "/": "bafy2bzacecllvtgved7fyn742o5ze6tgelf4zbmdt5ztlogbpv7bshvkhgysk"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacectoxgvgytbyglkejr5auyzkrd6e6wxnj5kltfwhm2pzcshvspxks"
+          },
+          {
+            "/": "bafy2bzacebxv72bcdyzizsmlo2lmrantrgowoyc3f4ectvhsgf7e42yiyfbnc"
+          },
+          {
+            "/": "bafy2bzacec5vks2rk2wjsvdvuchspx3jc7jpmlzbkibmoum4owe4u355e5536"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919713,
+        "PowerTable": {
+          "/": "bafy2bzacecqyg6ziyplhpzecbany3n624tfufeeyub4rs6ttvdzzanaa4bizi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedjlh3pid276daatdnii3uh4ucbj3l6xxjcej54klfbail26jksyu"
+          },
+          {
+            "/": "bafy2bzacedtkde7ejmj3ybqnibwdpk6wbozsdvtbd2arpth2ezvc222fazecy"
+          },
+          {
+            "/": "bafy2bzacedph4dzss2byt7cybqjwvpb6t32rx3udagp5tbkiueomqx4n3l4du"
+          },
+          {
+            "/": "bafy2bzacecxwn5pelzg2mqpxluyob4kyngcw2lewiphohwgduk4g4y4ufcjjy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919714,
+        "PowerTable": {
+          "/": "bafy2bzacebxauh4tnb6vxwl25neakkrebnvre22lkaetxclupaa34go2hhqlu"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      2,
+      1,
+      2,
+      1,
+      9,
+      3,
+      1,
+      3,
+      3,
+      2,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      6,
+      1,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      5,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      3,
+      2,
+      1,
+      3,
+      1,
+      5,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      3,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      2,
+      2,
+      1,
+      1,
+      11,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      2,
+      1,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      2,
+      4,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      8,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      12,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      2,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      5,
+      1,
+      6,
+      2,
+      1,
+      3,
+      4,
+      1,
+      5,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      1,
+      3,
+      2,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      2,
+      1,
+      2,
+      3,
+      2,
+      2,
+      2,
+      1,
+      3,
+      3,
+      7,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      1,
+      1,
+      4,
+      2,
+      5,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      2,
+      1,
+      6,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      2,
+      1,
+      9,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      12,
+      1,
+      3,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      5,
+      1,
+      1,
+      2,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      2,
+      2,
+      1
+    ],
+    "Signature": "tGUa/3BnRmDvYtkOmJYyvkjj2OVR6b3iv5u+FbEwEHQmRLWCseidCahBp84JvR54Db14WrAX4z4DKRYVb0kPKLDiWG74SgyiUWw7jKXyBWW2uJ7LuUWsFwJcPKKGpwPS",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 7,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedjlh3pid276daatdnii3uh4ucbj3l6xxjcej54klfbail26jksyu"
+          },
+          {
+            "/": "bafy2bzacedtkde7ejmj3ybqnibwdpk6wbozsdvtbd2arpth2ezvc222fazecy"
+          },
+          {
+            "/": "bafy2bzacedph4dzss2byt7cybqjwvpb6t32rx3udagp5tbkiueomqx4n3l4du"
+          },
+          {
+            "/": "bafy2bzacecxwn5pelzg2mqpxluyob4kyngcw2lewiphohwgduk4g4y4ufcjjy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919714,
+        "PowerTable": {
+          "/": "bafy2bzacebxauh4tnb6vxwl25neakkrebnvre22lkaetxclupaa34go2hhqlu"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecs4pxgspf4echasgnezvmmy7qn2mmg6lttlv4hfzesuzijnalspy"
+          },
+          {
+            "/": "bafy2bzacebflsldtq7a7hrpqpwfivrbpurhrjqng2dyi7yoletsw5dfdkhx62"
+          },
+          {
+            "/": "bafy2bzacedwyvh6mcvh7zbjudpihvhojhoid45dutecyjnrnylotwb7mgzfro"
+          },
+          {
+            "/": "bafy2bzacedy6iqs5vkdy2qg5ft3hkryq54actw3f4hfcffe6ldrda5ffdqi5w"
+          },
+          {
+            "/": "bafy2bzaced5u2bgwpmxqogoqrcf7e2hwx36rjty4uch2gvnay7emdmmrj22aw"
+          },
+          {
+            "/": "bafy2bzacebtlotyehsdct2dtc7o42ckg5s5hchpmy72x4mnl7op2ncjvixoxi"
+          },
+          {
+            "/": "bafy2bzacecfkkh2a2ea4nuf7zt6vhctdvdttehw2p4yi7ce75mvsu3rnbbnzc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919715,
+        "PowerTable": {
+          "/": "bafy2bzacedhadztpwovxhisu4hx32ap5tmbodnmphpscdstrwxc6blucwqg5y"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb2qnwuujcqvsjorj7axac5z3utq34sgowje4pjxam2cgiaghs2jg"
+          },
+          {
+            "/": "bafy2bzaceae4poqln4lfuldjai5f3iqs7nsl2bzeiglunz5ypyp3rvazfk4bq"
+          },
+          {
+            "/": "bafy2bzaced3w3kyocgrcehi5dxrvsreqbm5laofuxvahwai6734fo77inwgfc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919716,
+        "PowerTable": {
+          "/": "bafy2bzacedhadztpwovxhisu4hx32ap5tmbodnmphpscdstrwxc6blucwqg5y"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedz7fbn7omuxmdta3hbebuptvn3poqzo6djny3sowrbmtg6hpsmdk"
+          },
+          {
+            "/": "bafy2bzaceba6kyb7qlm7zy2mhywwdvpa2kvzy2dthyyb257obijcv5vtgtonk"
+          },
+          {
+            "/": "bafy2bzacec7n7zz2ywemhvdpbyzsg6xdw3uwhkmmf4bx64sehczu3aqs7va4e"
+          },
+          {
+            "/": "bafy2bzacebajfylf2eg5p6cjka6y5mh7cooozcgvop5gytmxf7l2dmzuqhpze"
+          },
+          {
+            "/": "bafy2bzaceaj2atoinqdk2oxi2jtey7qt4d4mhr3vlytkh53doddpg3ot6qdy2"
+          },
+          {
+            "/": "bafy2bzacebmeslxic4hwv5btlelgjm66taj5r2izw6hiap7uf5xm6jri4sfsm"
+          },
+          {
+            "/": "bafy2bzaced3eye5shruptydvtlc6df5rcapasb6dxfjgjrjzjy5phy7jprsmq"
+          },
+          {
+            "/": "bafy2bzaceb2t4u6gn4txe2cip2jf5aglnw2nxenwzichx5wfjjko5qryn3lei"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919717,
+        "PowerTable": {
+          "/": "bafy2bzacedhadztpwovxhisu4hx32ap5tmbodnmphpscdstrwxc6blucwqg5y"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecsuys57a5r57asedfr4cg575s7mhtwvw2fxffdyg4tf2j3onqm62"
+          },
+          {
+            "/": "bafy2bzacea37yva7asfdfuibsxdosopdslllifd6qntl6mb2ldbd4sbm6d3qs"
+          },
+          {
+            "/": "bafy2bzaceawb5qvuvswx5emguoy6jdu66r3bhuhngrihvrgap243xnbkyuf7w"
+          },
+          {
+            "/": "bafy2bzaceaboqzmxzz5bjyeyg3dsi4bnqdvrmwu2kppyj4naluc3vvfaycfig"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919718,
+        "PowerTable": {
+          "/": "bafy2bzacedz5bvzi7szvlto4dcabddu7zreev274xverqsovufxfmyntqmafi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebxa5u6u2s5lxcs2lu3nf5qcyzhkjxiq5em4bms4i7n4xp5253ru6"
+          },
+          {
+            "/": "bafy2bzaceatmuataagdzelmibkj32mfk4smcohwjwusevprtzyq46ggciolfc"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919719,
+        "PowerTable": {
+          "/": "bafy2bzacedz5bvzi7szvlto4dcabddu7zreev274xverqsovufxfmyntqmafi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec35tum5ig6jshpmttqghfwthbpyzdbqbepbitym5glyohgssflae"
+          },
+          {
+            "/": "bafy2bzacead7igqbq7vmatk6deqrmrvn5dhssinvcxbordk4uuw4oyimedmas"
+          },
+          {
+            "/": "bafy2bzaceajhsqpmtgxni5v44lcefrzrpdecax7j5znzrvvywsljgbaquu36e"
+          },
+          {
+            "/": "bafy2bzaceb5fdkg72myufr3b6k6o5d2wdxwtimx4juslkvchhclqwifuefzjq"
+          },
+          {
+            "/": "bafy2bzacea2zbir63wx65u46u7txhcat3fzepfnupbgwx4xi2gdg5k7nofyju"
+          },
+          {
+            "/": "bafy2bzacecgoh3sh3a3ntfa5wfnbart2g2akxu4mkgftehv5iygghbbj5sqf6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919720,
+        "PowerTable": {
+          "/": "bafy2bzacedz5bvzi7szvlto4dcabddu7zreev274xverqsovufxfmyntqmafi"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3ii2sw65mkipkznqm45oiu5t4hhnxj667ohyfn6ranrf37xe6ao"
+          },
+          {
+            "/": "bafy2bzacedqusmyonwhg5u7gdzxb5x2bodzbrwl2gtzuevqirltou4c27fsne"
+          },
+          {
+            "/": "bafy2bzacedkjjxib4y27edjebg2iptek3ns73njvymtd35tv3gcn6eeaks5i6"
+          },
+          {
+            "/": "bafy2bzacebwdvzf6qmld4ihj34bqbgx3qluccd4ci2w4zjzic35rgqzufzjku"
+          },
+          {
+            "/": "bafy2bzacedher35zb736lglqogq4in32dh3p6vxmrv5kleheikhdbmngljwq2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919721,
+        "PowerTable": {
+          "/": "bafy2bzaceb4fpgakqm6xgjvsrfe4nplr6i55cvhftktunxgv33ztqnuewzt5o"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebcqfidh3ofxyddotj4hk2ew72c4yvhsug6k52rchxoide5uynnzg"
+          },
+          {
+            "/": "bafy2bzacedbqlfjrm7nvqwybua2kdhp5moqrjmhxmynkvoqhysy43ljjhby3m"
+          },
+          {
+            "/": "bafy2bzaceau5ffmab6yblabtowxres4bkxzvkqb5wneg7cxaiuq5bqj756uhi"
+          },
+          {
+            "/": "bafy2bzacecndxz6e63ohzxcepfzxm2k77kisk4mbemg5xfjasulrst2zzzwqa"
+          },
+          {
+            "/": "bafy2bzaceatvwnisimj6sy5ct5lgg7vpsx3g4hbntbys75xxuoet6xkhkkf6q"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919722,
+        "PowerTable": {
+          "/": "bafy2bzaceajkirfkap2urlk75cypd45qv5cnryynaupkr44rue27b547r7q5m"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecxzym3ezpetgi6xqkoclh3qzdpmicsp3hrg3r4t337wnbniwimec"
+          },
+          {
+            "/": "bafy2bzacedkxyxzjtfm4oylvgeiefbmfsdzjsxff7qrd3mbrkllzhcr242sr6"
+          },
+          {
+            "/": "bafy2bzacedxe7fjbhqvam3d2d7umjexofk3euzqn2fmm72sspq4fbpksmkbnw"
+          },
+          {
+            "/": "bafy2bzacech5iep6vnosxzgeyzxmkha746qai4253tt2ltpya7dooxnrunjxy"
+          },
+          {
+            "/": "bafy2bzacecgufhbmu6rofj6mdwrrmyzawr2rhhmeoyont2wvyhj47t2helhhc"
+          },
+          {
+            "/": "bafy2bzacedhhvs7wtj47tt2oqjg7nbvxnefapyjlrrl4v3k6yhrjam4k46u2k"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919723,
+        "PowerTable": {
+          "/": "bafy2bzaceb7blcb36uemb4jvjx3dgyq2lt4vbblrdkkexjgg5d62fpuxbtaiy"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb7va2sesyh53uukqte3q43rbea346mygzlcqcq2glnj23umsloec"
+          },
+          {
+            "/": "bafy2bzacebpk4shnjy2odxth6tlfi7s5mpaxcj6gx2dgjrpy4di2iytrx2nou"
+          },
+          {
+            "/": "bafy2bzacebtdmhc7tkymxgr3c2jlmpjvve5rvkwvdr42iolokphdhtphwv6wi"
+          },
+          {
+            "/": "bafy2bzacebraqzbimug6qyakrsrsanwnc5kqwrsgscz4yh5ymmn5cfmtbrob4"
+          },
+          {
+            "/": "bafy2bzaceda6eplu637yzyrjonapfbiteselpjnrqn3yp62ubfgcty34fqfas"
+          },
+          {
+            "/": "bafy2bzaceazhqawpuz5heksj7jgeik4z6qsokrwtdkuklpdynbbexz33t6rqw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919724,
+        "PowerTable": {
+          "/": "bafy2bzaceaebftqvzoeonzxrcrxx56cj43jv7tz4t6fjhcajeneflztoa6awa"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaec47zfa7h2hykrimhpf7zhtcjdrvmpyql7mgl5ngxvrwqdke6cg"
+          },
+          {
+            "/": "bafy2bzacecghe57okkyda7iiqurjiiuwbejmsve6vxlvcjje7fokavtz33j7w"
+          },
+          {
+            "/": "bafy2bzaceaao72xnyrcjraq5ju7syqnpajogomhvn6ppk6rfkw7iypo3yqrps"
+          },
+          {
+            "/": "bafy2bzacecb7n4pflo25h6qllkoabwm4pfvlgqr32zzpdddxf7wxg7ru2h73o"
+          },
+          {
+            "/": "bafy2bzacebl4jwlf3rrbbm6erl4lr6jrws43tlcxdjg365ubgrwygwel5iehe"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919725,
+        "PowerTable": {
+          "/": "bafy2bzaceaihmdfxofp4z32x67tt74fv6xam5tdtvclrjwtbkn2xgjk4rtbhm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacea26omglupnebmoodlascnotpnlapp3ldfervnwmogrkqbjnonicm"
+          },
+          {
+            "/": "bafy2bzaceaqpvmgqphl54ghomsmp4ntrt5othasss3qpoqjqvdf5i3le2hgoq"
+          },
+          {
+            "/": "bafy2bzacecdbmey56westdbazvfgyjm5c5bu2le7kmoyclakjo2l65iww7sf6"
+          },
+          {
+            "/": "bafy2bzaced6sapnkccupim4ufi7ny747tqpbkx34s6xz2zvqjwwg22dvbj6vi"
+          },
+          {
+            "/": "bafy2bzaceavenqacolvposwe6vgexognnazyj6v6xu75r2s34csu2tbl4a5u6"
+          },
+          {
+            "/": "bafy2bzacebd35ia6noapjnojm6sb4ghx2homsab5lolx7c4i4azmrtjmdsipg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919726,
+        "PowerTable": {
+          "/": "bafy2bzaceaihmdfxofp4z32x67tt74fv6xam5tdtvclrjwtbkn2xgjk4rtbhm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedqxsawyn4tqaex2dkmnzgjenkkj2z32iprzfw6bi5k5ebnscl3se"
+          },
+          {
+            "/": "bafy2bzacedkxjse7v7466kygemurjqeqe6gorxicpbu5nnfiteoeaawjsm73k"
+          },
+          {
+            "/": "bafy2bzaceazsk5kecdpdbjjg7u6q73a3vjuwfx7ebcgnzmx3g5gnrse5g2xag"
+          },
+          {
+            "/": "bafy2bzaceam4ul3a4paat4ryg567kqnry7ola6qigvlncy25x5ch46yvmgczy"
+          },
+          {
+            "/": "bafy2bzacec6bmkudbxsuskuiw6mm3zav2rxiozqujt7mvqhzqpnohyrywtyk6"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919727,
+        "PowerTable": {
+          "/": "bafy2bzaceaihmdfxofp4z32x67tt74fv6xam5tdtvclrjwtbkn2xgjk4rtbhm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebgd7kbhzboefp5cjyy5qex2kgqkxde5svkrdknwbxizauouab7em"
+          },
+          {
+            "/": "bafy2bzacebujevvni5srz4aqpgiyxx6bzmubouds2bxusrizj3s25yqsbn3ag"
+          },
+          {
+            "/": "bafy2bzaceazzs443gfb44dzpiorsshr2ou5xcw3kcdfw3hkzsulgcb35gq434"
+          },
+          {
+            "/": "bafy2bzacecnu6um6m5r5qpevtj5wik3uod4hu5beusbbyjbr2zehoiw2n4xei"
+          },
+          {
+            "/": "bafy2bzacebcawjxjq5amwtr3cnyysmqqmacp6vwyvfkgy5y5gsm6sij375jzk"
+          },
+          {
+            "/": "bafy2bzacectq6xjwhzg34pwu2vdqtdvkn2numunxu6vugdmfppk7rzi7hljrw"
+          },
+          {
+            "/": "bafy2bzaceb2twf67qd3qroesyfeotxg4ljbrss5uncp4bslrer2rghd7ramcy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919728,
+        "PowerTable": {
+          "/": "bafy2bzaceaihmdfxofp4z32x67tt74fv6xam5tdtvclrjwtbkn2xgjk4rtbhm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecz7vby3o5xfld2cn4osnmqgcr7nsiqb4olrpr2yroemtfag56tfy"
+          },
+          {
+            "/": "bafy2bzacebvyzad3xh674m2tssuq6lk44gxwykabtww4g4ltkneq5hs5t2sdy"
+          },
+          {
+            "/": "bafy2bzacedp62nyhmofu6pa3fhnntlh6jov3o6zn3bu42e52vgalqr6akdsmw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919729,
+        "PowerTable": {
+          "/": "bafy2bzaceaihmdfxofp4z32x67tt74fv6xam5tdtvclrjwtbkn2xgjk4rtbhm"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecmjzmt5t3ur7tvgdidgzxq6iph62chcd4azq7vyoaimku2dscu5s"
+          },
+          {
+            "/": "bafy2bzaceacsbptjldvvb5noudys7wz5oni7q7caiqvvzed7vojeii2ylfida"
+          },
+          {
+            "/": "bafy2bzacebktu4bodasuinmy7npchleudm47gcrqyvgz6zlyen4llvnk6elpm"
+          },
+          {
+            "/": "bafy2bzacea6nu4zpd2xbb7mmjuaygeig56f52ynz436oxmkvysoxa6ay2bir4"
+          },
+          {
+            "/": "bafy2bzaceagbmi4jhuksg4iwqtdtkb6h37mw74sko6rc3qdmfq2bjzxbdbjiw"
+          },
+          {
+            "/": "bafy2bzacecr5w77gx5jn4uz3bzpoliwtzveywhuebpyean7cxtkvyt6a2opse"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919730,
+        "PowerTable": {
+          "/": "bafy2bzaced6zwd4tvwcfm4uhamh6getzicoyilwj274lf2vqus3u6hywefzp4"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecbucny4saak7qlmautet2zon2yca2tu7picx4mufvvjynk5leuc6"
+          },
+          {
+            "/": "bafy2bzaced3wfqbjh7owtbrarf7dznmdbkaw5fdq427cpwpzu7osuvf3wqbdu"
+          },
+          {
+            "/": "bafy2bzacecnefdmv6nsbt3qjhj2ux3qsrdc52hzvhfoprn43fxxcjeh7iyrqk"
+          },
+          {
+            "/": "bafy2bzacecu4klhqqklfmjvckt2x2svkmkirfygmuqvcr74gr6y4gwspoosvc"
+          },
+          {
+            "/": "bafy2bzaceddkf3j4j3bcaqa5lmaqsgly2yu4bwb7xtol5nfltmuplxu2xnhka"
+          },
+          {
+            "/": "bafy2bzaced5fu3fnuo55gpng2tbcubxjnemwkl36yfbzmfpjn4hzwxbdferag"
+          },
+          {
+            "/": "bafy2bzacecdfbddkzmafv3ipgtzcx6t47x4m65mxtprlhdx6o3ppdp6vxy5r2"
+          },
+          {
+            "/": "bafy2bzacecvwkoq5eyvecuxf3k3jv5epgn2ldzuzejkrvq5gldvodbh7jzvpm"
+          },
+          {
+            "/": "bafy2bzacea6t2av53pt5zbslzzcf2r42kf3hcs2i4ur46foglrciyf6b7k722"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919731,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecmd5tbij26doau54ngpmdzs6epdkwflgil6n7fs2ycwjtrml35uu"
+          },
+          {
+            "/": "bafy2bzacebp3gtomsyz235sgoywk3qezdqpdq6pqftjsopyxhpgfxme6k6jp4"
+          },
+          {
+            "/": "bafy2bzacebicpwxo434mb26ktk4qiucrkr6twblqeaygajzwdmmph5sbvtv6u"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919732,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceatgv5dbf5q7ydiwxua22yx5vdex2fmehfpj5neadj5yzrwf4accu"
+          },
+          {
+            "/": "bafy2bzacedtkivlnywy4eddq36rkxvmv6w7fdj6jotstp6zgabvutvswlufjq"
+          },
+          {
+            "/": "bafy2bzacecwab6ou3knejyg427skgncmiwaa5mfdhti53i5chncl3j2x2ophu"
+          },
+          {
+            "/": "bafy2bzacecrzpaet5mu6wiqwtmozimo3nuxle2vttupsnkejsamp74ijk5n6a"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919733,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      5,
+      1,
+      9,
+      3,
+      1,
+      3,
+      3,
+      2,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      5,
+      2,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      5,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      5,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      3,
+      2,
+      1,
+      3,
+      1,
+      5,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      2,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      3,
+      2,
+      4,
+      2,
+      1,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      2,
+      4,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      3,
+      1,
+      1,
+      2,
+      3,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      2,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      12,
+      2,
+      1,
+      3,
+      4,
+      1,
+      5,
+      1,
+      4,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      2,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      1,
+      4,
+      1,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      7,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      3,
+      1,
+      1,
+      3,
+      2,
+      2,
+      2,
+      1,
+      3,
+      3,
+      7,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      4,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      2,
+      1,
+      6,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      2,
+      3,
+      12,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      2,
+      8,
+      1,
+      1,
+      1,
+      1,
+      1,
+      12,
+      1,
+      1,
+      1,
+      1,
+      1,
+      10,
+      2,
+      2,
+      1,
+      9,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      2,
+      2,
+      4
+    ],
+    "Signature": "qutiAWOpGQn0SN2PK+kC6UurwbyK0fVC0RdXykxxkwpK+19cvWRqTWJbsh5kiQdkB/R5ZQb9utQCMtmJI7qJqinzVFYKLWljBgpsUB6NBCyYqfKrnhyCuUI1gu2pohBD",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 8,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceatgv5dbf5q7ydiwxua22yx5vdex2fmehfpj5neadj5yzrwf4accu"
+          },
+          {
+            "/": "bafy2bzacedtkivlnywy4eddq36rkxvmv6w7fdj6jotstp6zgabvutvswlufjq"
+          },
+          {
+            "/": "bafy2bzacecwab6ou3knejyg427skgncmiwaa5mfdhti53i5chncl3j2x2ophu"
+          },
+          {
+            "/": "bafy2bzacecrzpaet5mu6wiqwtmozimo3nuxle2vttupsnkejsamp74ijk5n6a"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919733,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecwgm6zwxjgns4xzftarj5c2vkuz5kee57v3r4r4ye42j4o6dvsiq"
+          },
+          {
+            "/": "bafy2bzacedwyjqkoejl2ityn3jk4ikx7h7hpyonmkb2bzntxerddudpxwbbe2"
+          },
+          {
+            "/": "bafy2bzaceca2fibppgxwlnrdx3sviuya2xagj5x6se64dlovrvjjsjnzbkivw"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919734,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebxfnfktajqwrwhs3ltsq74lyk2pqcro7cocp2qxom62kmgnmeimy"
+          },
+          {
+            "/": "bafy2bzacedkko4uzhr2ibtrbd3vzb4rgt7b47svtr5vzyl3a76664yvfkv7pq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919735,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecu3y3lppgrpy3hqdu6cmavhwfsjj5fqcoa5iwh4aynbhqgd4d7c2"
+          },
+          {
+            "/": "bafy2bzaceb5xlpdqvu2ldvazkvtsvt4wouiud3c54rcbidj2cuogyz2zr74uu"
+          },
+          {
+            "/": "bafy2bzaceb7ygnwfq2hk5mpuggboigvb6zdxjabsh5dmkpg55iwxxrlu5txng"
+          },
+          {
+            "/": "bafy2bzacecvcu56btajim3q5mlso6o5k2d6jd7g6zythylqwull3m6hmlk4oe"
+          },
+          {
+            "/": "bafy2bzacecodmomiss3ynvum4flecml7zrpusqo2aoxgo2ow6okht4qeefnco"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919736,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceawpy7zvyqodpnujb2xqtrpsucwpyuqkjvav77mkryl2kfafit5gg"
+          },
+          {
+            "/": "bafy2bzaceaoa4yhf7ls5ww3lae7enwd33mq7eb6bc347rrplayoehw5e3dib4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919737,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb7hbh3zuk2meovkm7bnsrylqwcmnqnamd6gb46uubml32zw7id36"
+          },
+          {
+            "/": "bafy2bzacedoi3qglr4tfcksm37d3q37havg6j5gdwh6bmdtprpg3gxnkagwpw"
+          },
+          {
+            "/": "bafy2bzacedytonuoav7epp3fp4ihnc7oxo27snyuepgzdrvzgrktuyo3fx64o"
+          },
+          {
+            "/": "bafy2bzacec4577pjl3kit3z6bzmqcvm2v2jdl36jwkwbxmcqetjx4uujxlxmc"
+          },
+          {
+            "/": "bafy2bzacecw4eab5tkkmgnujs7coxyo3ase7lebgnowbxrynqpjtg2w2dq2bg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919738,
+        "PowerTable": {
+          "/": "bafy2bzaceb4oe25inhalgj2gmojzql5hb4cjho22ujnc4e3amn6zobfvtcz6c"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebfp4ypcan65lhgi46ibh2rhgthouqak3nxow2vhwyo67rdw4znzw"
+          },
+          {
+            "/": "bafy2bzacect6oc2ksdtdpog6hfm6qmoue4xgpprvb7hcaqd7buvuk5auxm4ng"
+          },
+          {
+            "/": "bafy2bzacecyyjm47kte3qz6h5wu4phpt37rbesmnqeg3kxvgxbsmt7yjeuvoc"
+          },
+          {
+            "/": "bafy2bzacebmg26fahfwnkjpangyrepclavjhg6mit2u6276ru6zu5tq7z6jre"
+          },
+          {
+            "/": "bafy2bzacea7ofxjsyexq34nmmgksb54den6oxr6e4lh575i363ywlzrzyblmk"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919739,
+        "PowerTable": {
+          "/": "bafy2bzacebmnjariwt4ldhneewiishhuk7agmo2hrrh2koqbj6mr5372txqnq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebhcwdsgd5ielwhed7od5mcn6scq2x7xlifesg6dguysqcyghlgk4"
+          },
+          {
+            "/": "bafy2bzacecay6rbfqfjtypyzcto37rn7amvt3uyvrddxbspkqgt3pn3r6se2u"
+          },
+          {
+            "/": "bafy2bzacebs7nqgs3ge7ysh4eweuhyrnbngc63ijnswyywfwuic6jzz6de3me"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919740,
+        "PowerTable": {
+          "/": "bafy2bzacedz2lwl7gaf3jqclelb56uzeimj4wlt5ckx7rx4zyug7gdtd5e4jq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebiwig3jm77zwmovt7v654kai7gzyfedacwhigbgnserk6yr4zgtg"
+          },
+          {
+            "/": "bafy2bzacebsddschchyrascwan4ku3u6pjesjvzgbct6piriium5kantrrzsu"
+          },
+          {
+            "/": "bafy2bzaceavbvbrjy3mn3exxuzxcnsb6kclpgkzavr3x3xyxjh5yneahpd7si"
+          },
+          {
+            "/": "bafy2bzacec4w7clpoz4r54up5pqiusdvbz32p6srw2pzmj7ruqhck3a42usbe"
+          },
+          {
+            "/": "bafy2bzaceaoegc2y4luoskurfp6c3wxl4cmjh6cfbvgmmebqpio2yjvvg4omk"
+          },
+          {
+            "/": "bafy2bzaceayhg52ymdfsq7zkcwzub4zxhgcwwxrphcjejcuqrgbulsd2y2tiu"
+          },
+          {
+            "/": "bafy2bzacedlq3y27clsltvlxlu2pvlmqebguf7jrlwbdawbvjgybjyof7sr6g"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919741,
+        "PowerTable": {
+          "/": "bafy2bzacedz2lwl7gaf3jqclelb56uzeimj4wlt5ckx7rx4zyug7gdtd5e4jq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebqwocnswysr3ptx2zxfoptfdk22dji5ebdf4qli4zy56gw422dbo"
+          },
+          {
+            "/": "bafy2bzacecjkzb5vfmw3yqq6y54obcu7gosvx63flndiho7nbky2yuo5cj3gu"
+          },
+          {
+            "/": "bafy2bzaced6tfxqqddaexzfmrgb7mplsll6covoqzei4uosovcqeyhbawml5o"
+          },
+          {
+            "/": "bafy2bzacedxfyyoyalpe7qshh5raivfpxbveya322fz6pynd4rhbfyfx4wyr6"
+          },
+          {
+            "/": "bafy2bzaceb3dnqiwdtfwrxvcmgzbsz7iuouhcjljaqvekeu6ohe75yurub57q"
+          },
+          {
+            "/": "bafy2bzacebjgovfmr6p5jdsm3is6xslnghl3ti3bnuq7aqoiqfgvsxe2ashqq"
+          },
+          {
+            "/": "bafy2bzacebnxgnic4y5bin3kutau5vducpjqkwngxe4nts2glzqwrpcawjv5g"
+          },
+          {
+            "/": "bafy2bzaceduzxqkn2cxhvoo2y4iie4v23l2whxy2fvq5o35coju3lxywfvcrq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919742,
+        "PowerTable": {
+          "/": "bafy2bzacedz2lwl7gaf3jqclelb56uzeimj4wlt5ckx7rx4zyug7gdtd5e4jq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb5ssugigaxsepccbztrtozr7mf7tpdbqfqcomkufu4l4c4muncwm"
+          },
+          {
+            "/": "bafy2bzacedpyngsptxef3hgalyrfnlcbwqcayuwon2zoetuvzsek52zdxf2zs"
+          },
+          {
+            "/": "bafy2bzacealetp53ezaf5pmj7bxww47c5il5v6dh7evkp3vmqwfkgpnj2avcs"
+          },
+          {
+            "/": "bafy2bzaced7tdyosmnetsxmnh72xw4xfsbj3a2cbmn2dcqtgloowcvu5yhiuk"
+          },
+          {
+            "/": "bafy2bzacec44rjl72ko6msk25m5uxp5qvvpedpvpvk47pkrl3sec2jc67bngg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919743,
+        "PowerTable": {
+          "/": "bafy2bzacectv77qqld5nrrl5egwr46hlmprhhrw7cnmed2n73jgpxfem7donq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceakxp3fprymprggsysil2i4qc3kkbayitehsllqrymwtwtfcellfo"
+          },
+          {
+            "/": "bafy2bzaceb6y7bvwmaxqj5q6ai745zjsdojz4u2h5atwmstvcfk7nac3vzuoa"
+          },
+          {
+            "/": "bafy2bzaceantm4kgfywb2wukogtb5istthxcceu374lmmbniirabr4pqgpkna"
+          },
+          {
+            "/": "bafy2bzaceajylyeoaqum2gvkard5st2triq6e6wzdqac5ubqpfbln3cccxw5e"
+          },
+          {
+            "/": "bafy2bzacedw73p2pocoxlvwilz6gsocx2idb7vhslyn6sbnnqzlbflzqqxfh2"
+          },
+          {
+            "/": "bafy2bzacedam3vp7rmndzqrklom72afuk22fg6fliryzkfvelkrcjn3mr3keu"
+          },
+          {
+            "/": "bafy2bzacecdifcytfddgclqqcajatdarhody3zk2gm65vlnuu66h6vl5nbclm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919744,
+        "PowerTable": {
+          "/": "bafy2bzaceazwkzdocitr3k4cpw5d2vfovw5lcvzqm2ko6g6h2cituwehykhn6"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacealsxw5n6jhm42stllyorfmhe4bgqs7wksyglrr75n6z7h4wshgd6"
+          },
+          {
+            "/": "bafy2bzacebu3uqdinsllchzubvqa6d3qlvwkyls3quv46slgmad2amulpmwp2"
+          },
+          {
+            "/": "bafy2bzacedtxuyvrmxbdh3uqvh4uo2wu4el3vm6iqhuymdfgiwsvbdnwrlnne"
+          },
+          {
+            "/": "bafy2bzaceb5vkglvy4hvm3ax2fdcmc3tu7s4waaaiqxy5334kv7xeucktdrpy"
+          },
+          {
+            "/": "bafy2bzaceanwqjwreu6m7jh3gjjh2bp2fbusxttpoltm5mhd764pqtdst5cg2"
+          },
+          {
+            "/": "bafy2bzacec634qztdpqrff7sv4zpywaihv6cin7dqk3mvgweui7vuf632apn4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919745,
+        "PowerTable": {
+          "/": "bafy2bzaced5a6gk7p5mk4xbywhkvrd5vchdygjpz7vkua35xspqlmtpbk55om"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaalkcxzqvgvhrvsj62lkf6yjkojybgvpcyoib7ye4llatymv6cmw"
+          },
+          {
+            "/": "bafy2bzacebbwhduddazxeuxmdhkrtc25meuut3qfgiemjhktctmpl6bytfeak"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919746,
+        "PowerTable": {
+          "/": "bafy2bzaced5a6gk7p5mk4xbywhkvrd5vchdygjpz7vkua35xspqlmtpbk55om"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecx34it4jxdqejd4c6dkkvgkspbskomav652z6idibdzbyh4i4l5y"
+          },
+          {
+            "/": "bafy2bzacebvmhbnnn3encjmi4t2cng7zzs36zqnqlyx53pwrdzj6eetddl37s"
+          },
+          {
+            "/": "bafy2bzacebbz4a4cgv4nzq465tsrhyupegvf4rnq3uexyfv3g62ylpj5gnxr4"
+          },
+          {
+            "/": "bafy2bzaceas4zcraotzxya5ui3f5lu7glcvryxdcizhttqc7wezwuedqxn52c"
+          },
+          {
+            "/": "bafy2bzacebd5dc2fkour2a3od3lpy32ufhoxjh5mpcdwjllmogdclo7kikdqo"
+          },
+          {
+            "/": "bafy2bzacecjrzm5zkefg4tu54ex47mioiho6lmkj2utuxm6hwfiblhwfokcqq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919747,
+        "PowerTable": {
+          "/": "bafy2bzaced5a6gk7p5mk4xbywhkvrd5vchdygjpz7vkua35xspqlmtpbk55om"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebkc5efia5tjy2igknswbheurvyrhure4r57gnq6npgwkq4hiczsw"
+          },
+          {
+            "/": "bafy2bzaceabd2yvnbovbahxksvqhgkdnqjbbakcux3kws7g73qp36kcwet26a"
+          },
+          {
+            "/": "bafy2bzaced7hi3zipk5q25fjcfpwy7voobazcycd4xg37gprd5rtrtkalorjs"
+          },
+          {
+            "/": "bafy2bzacecdgpw3h3wkayxuibmgftdlp66zom5v2jzaoxst3posajwnq4ksps"
+          },
+          {
+            "/": "bafy2bzacecq2pbhpvvd2dtg3vxh3o5zovrp6kfilvl23e2es5edaetkuvht6e"
+          },
+          {
+            "/": "bafy2bzaceazcu33ulb6ixa46stb6kicjzsewatm7ccdyuilc7amu3xsawtzrk"
+          },
+          {
+            "/": "bafy2bzacebs34qqmiyjvuf6mew35rfkpeo3mcrg3wu5eme5iihcc6vlqznmwm"
+          },
+          {
+            "/": "bafy2bzacebbww6v47ilwms4n4dgxy3ff4fkgncodozdyvdhdiew2wczygixdo"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919748,
+        "PowerTable": {
+          "/": "bafy2bzaced5a6gk7p5mk4xbywhkvrd5vchdygjpz7vkua35xspqlmtpbk55om"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecfufapbneyompbeamdj3csd7dybj2nahji7wnt3ecylg3huwzbiw"
+          },
+          {
+            "/": "bafy2bzacebhiigvhupaisuxpebmaecb57iqlvbdbfgygvera2skez67z6sh5o"
+          },
+          {
+            "/": "bafy2bzacearuyufp4vipojmxk6xskz2cpubufnza4cxjzundml4ljoundis64"
+          },
+          {
+            "/": "bafy2bzacebtbtrqpwp6ebs4wcaf3n4lwqsmqlvnuh6722blzdffuwkx3ylemy"
+          },
+          {
+            "/": "bafy2bzaceadngtjtoxnasqylbv67jgs3rd52wknsyiwuu3wqr3pildetsebro"
+          },
+          {
+            "/": "bafy2bzacecuriz5vcdpne6ta4i3awfpq4supugtfklkjdvuakhx734elbxsyi"
+          },
+          {
+            "/": "bafy2bzaceaju3mqvcldalsjaaid6swtff5e6lbv4zceyqdstoji2r3dvf3jrg"
+          },
+          {
+            "/": "bafy2bzacedvjwndk6maro4egipqyft5hc7ttjr75cbb4agnvk37zzol5mbwpk"
+          },
+          {
+            "/": "bafy2bzacechexf6d5fah7dyu5bx4kp7c3qclvi3ezcezrkmacqb5dpnoglnya"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919749,
+        "PowerTable": {
+          "/": "bafy2bzaced5a6gk7p5mk4xbywhkvrd5vchdygjpz7vkua35xspqlmtpbk55om"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebcy2a27hxs3v65lpl6faehxbxseoisxl4uj77px3iyqlrjnp4waq"
+          },
+          {
+            "/": "bafy2bzacecyldbxthq5pay3aedhzryfd2ivaxopbi7b6k2anwge3rxkjcijzm"
+          },
+          {
+            "/": "bafy2bzaceb6p7iy6n5ft4nzidhvgfrqgmxx3rivwr7mw4wamajcwphkr3eeam"
+          },
+          {
+            "/": "bafy2bzacebizro7ogvau5r5jdcbus2eootstfrgvsd6eub6t6qlvvvhogy7ey"
+          },
+          {
+            "/": "bafy2bzaceao2jyozqf2hfsqpm4w7lxwrc7b55c5pypgbhmkbi5nqelnz2hcr2"
+          },
+          {
+            "/": "bafy2bzaceb5o765ahjz4wl77tlg44sxxqa3kx5vn423nzmg5ot7awmhg6mta6"
+          },
+          {
+            "/": "bafy2bzaceciz4achg4wr2yqhhnw43mnnaxql3c25rwhx4k3oo7rfarhmbkuog"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919750,
+        "PowerTable": {
+          "/": "bafy2bzacedbpz7fxccdmdqru56fobgq4sw4qw3bnlj2cnlsft6skbsrtzqiqe"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacec32ymd5aldlciaeubultkjnmm5zpo32dahp7v5l4lp4cpklcb646"
+          },
+          {
+            "/": "bafy2bzacecgs2fmi472xye7a7dzqw5u3o3zy7bfpvjg6cotgconudcoyofh46"
+          },
+          {
+            "/": "bafy2bzaceax2nojy4t5pb55cpwvaz7da5qfkisb6trydfkzr5hwfpp6lrvzaq"
+          },
+          {
+            "/": "bafy2bzaceaetq3m5mhxj6ab3xdf4d2jxalvf5s4afs3n2ni5xiiq7fs4choxi"
+          },
+          {
+            "/": "bafy2bzacecg7omtpia4uyw54xmicnyc6rruc2xhulw3x7hzdwkpjxfudboy2s"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919751,
+        "PowerTable": {
+          "/": "bafy2bzacea4cykvrcmnpp24kfao4coyxo2oe6u4e7zgzxb67vm5p5z4w7s3pq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaqsbxd5reiik6knflf2bcqswr4wyoblaivyui37fvt66dyb3jp2c"
+          },
+          {
+            "/": "bafy2bzacebdnjs6ivb2byl2iguoe3kvch7ujniawpgvccxoqksyzma5lslkue"
+          },
+          {
+            "/": "bafy2bzacec3u6ynmvy675awpyk52vylvnklohafaopr2soohnkzdog7ckfizm"
+          },
+          {
+            "/": "bafy2bzaced65opkiznswcbnegfoel74meikzhk2brpfipy3sqmj2o3uoi5y6u"
+          },
+          {
+            "/": "bafy2bzacecd67latc3dvjaeb6njzp4ph7a6jzcnmrhcbi2bbhwruzhe3nqxa4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919752,
+        "PowerTable": {
+          "/": "bafy2bzacea4cykvrcmnpp24kfao4coyxo2oe6u4e7zgzxb67vm5p5z4w7s3pq"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+      }
+    },
+    "Signers": [
+      0,
+      5,
+      1,
+      9,
+      3,
+      1,
+      3,
+      3,
+      2,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      5,
+      2,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      6,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      1,
+      4,
+      2,
+      1,
+      3,
+      9,
+      1,
+      7,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      2,
+      1,
+      2,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      3,
+      2,
+      1,
+      3,
+      1,
+      5,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      8,
+      2,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      2,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      4,
+      1,
+      2,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      1,
+      5,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      7,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      2,
+      5,
+      7,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      12,
+      1,
+      2,
+      1,
+      6,
+      1,
+      9,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      6,
+      1,
+      4,
+      2,
+      7,
+      1,
+      2,
+      1,
+      7,
+      1,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      2,
+      6,
+      2,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      2,
+      8,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      3,
+      1,
+      8,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      12,
+      1,
+      1,
+      1,
+      1,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      9,
+      1,
+      7,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      2,
+      2,
+      7
+    ],
+    "Signature": "rX30t16Vy5hhb8eNHov0KTzlJIm0m5EU05loJX43XHBHosUK1w9pdLhpDED11PB0CSvNIRY3+Ze/xV8/GYiioExt18OGc9uwW6GrgSxXChZpLE8+QSkBouwO5w8TDy8P",
+    "PowerTableDelta": []
+  },
+  {
+    "GPBFTInstance": 9,
+    "ECChain": [
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaqsbxd5reiik6knflf2bcqswr4wyoblaivyui37fvt66dyb3jp2c"
+          },
+          {
+            "/": "bafy2bzacebdnjs6ivb2byl2iguoe3kvch7ujniawpgvccxoqksyzma5lslkue"
+          },
+          {
+            "/": "bafy2bzacec3u6ynmvy675awpyk52vylvnklohafaopr2soohnkzdog7ckfizm"
+          },
+          {
+            "/": "bafy2bzaced65opkiznswcbnegfoel74meikzhk2brpfipy3sqmj2o3uoi5y6u"
+          },
+          {
+            "/": "bafy2bzacecd67latc3dvjaeb6njzp4ph7a6jzcnmrhcbi2bbhwruzhe3nqxa4"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919752,
+        "PowerTable": {
+          "/": "bafy2bzacea4cykvrcmnpp24kfao4coyxo2oe6u4e7zgzxb67vm5p5z4w7s3pq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecrblsyn7jzzkv35jav4vyhbg4faxxnfl5mhq7wmbb2sbkgqsv6nc"
+          },
+          {
+            "/": "bafy2bzacearsaspr2nxdms245g7lvvc7kfwdjrzvivlxrzbkecivxgxekwmiw"
+          },
+          {
+            "/": "bafy2bzacec3e7vwoonpaiesbx3tvgfzwqoigc53uka3yt3ttgmip6wa4cdtok"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919753,
+        "PowerTable": {
+          "/": "bafy2bzacebiy57ypbmgegsmx34csbpfhqcbfxhnfh6ri7gdjcrj3ktx3twxn2"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceb35ggxdertouiocvarvqez7gsnvshgxk2xkqthvdccrwxcyuvpyw"
+          },
+          {
+            "/": "bafy2bzacearvx45dsbtxdc3zakbfwszn6qlmpx6bm45frtbvsqtxxze2d6z3a"
+          },
+          {
+            "/": "bafy2bzaced6u4kvekdqrsu74w22reyvn7d44uwkczglchh2mkchrpp55qjrqa"
+          },
+          {
+            "/": "bafy2bzacedfdctno4vt6f5uejcekb6aqhc7oityxyf4aabipv4zxi7x6gitdw"
+          },
+          {
+            "/": "bafy2bzaceafpe3b6gr4wuum2etrbnndo3ytz35z65j5drnv4pkk6io5pcmffa"
+          },
+          {
+            "/": "bafy2bzacebq7dujswe5zbcjybnytb54rnioaum4gef52v6qyvlwhzgwdnuazm"
+          },
+          {
+            "/": "bafy2bzacebykzxd7vb5vzz4jqtwvnsq2bggacbwg62udi4qyhaz5sbaxt56c2"
+          },
+          {
+            "/": "bafy2bzaced5bsdm72cqpucgmx66sw3yfiegnmiwr7fku4mczdkiqbtlxryyt2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919754,
+        "PowerTable": {
+          "/": "bafy2bzacebiy57ypbmgegsmx34csbpfhqcbfxhnfh6ri7gdjcrj3ktx3twxn2"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaced3xdvjiwkhcljanslyfqm4xvaymmno2cnlldx2sosbz3vq3xmbxs"
+          },
+          {
+            "/": "bafy2bzaceb7b7ouislbr5r42mzgir64qlxmrxuq5pws6ygeqfphzpwh3lnjak"
+          },
+          {
+            "/": "bafy2bzacebvzn22ijcq7tlhkhj6jlloaibfarl5izemyepx3newblro6xjtgy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919755,
+        "PowerTable": {
+          "/": "bafy2bzacec52nklcpfcvxpboj62eddukilafo6psqmyyb7anezxotcqmbzlus"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecjso4ytnghw4mhgthjkcxybmqsbaen6n23ximxsqz7xqz5pfbhli"
+          },
+          {
+            "/": "bafy2bzacec727u5wihtqcx5zu6w2vkykgh3g2ikuvvhenra64zmhbrlpjoqdc"
+          },
+          {
+            "/": "bafy2bzaced4jqfcyx6lnsojpq3n2bj5nqd7a2xfnjtsozdcbgo4rkevyifjp4"
+          },
+          {
+            "/": "bafy2bzacedcj3zkaqnfdsxkvspz3bu56rrohlu5nsewbfhm6e5jubswc52iwa"
+          },
+          {
+            "/": "bafy2bzacebwudqgfdp5bj2h7qituezrb6jfv4m76x6y3ccrhqcjhcd342y6yg"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919756,
+        "PowerTable": {
+          "/": "bafy2bzacebugkf7swzihuwqkfwjyvm6rfd5gvlfhxeghsehsmat3kjca7svyw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceciiinp55u7o2ylaek2xcatbfiyljqwhmhcv67jst6si3jzwfiaqq"
+          },
+          {
+            "/": "bafy2bzacearel7alsow34p5mbkmqficvb7jblikx5m2wqm2exnj3usnf5vm6e"
+          },
+          {
+            "/": "bafy2bzacebbxbnyvhvzkyidaxhnzxbgbhvtsdgmc7jyzytrgly7tqro3m45dw"
+          },
+          {
+            "/": "bafy2bzacedjlth7tdx3zfci4jseal3zlqdkze65ic23wnxm67dkgyikqt5ljs"
+          },
+          {
+            "/": "bafy2bzacebwgeas5icwp5uugww4ktxz4nve3qofc27qfxe23mcejch5la3cee"
+          },
+          {
+            "/": "bafy2bzaceai43szh3pmb27zlm5gtzscoetoflqw6vgjlyhbossezuq7s6alvy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919757,
+        "PowerTable": {
+          "/": "bafy2bzacebugkf7swzihuwqkfwjyvm6rfd5gvlfhxeghsehsmat3kjca7svyw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaioh7i5vgnblilntbg5nrpahg4xyj2x7hc2ejk7wfxdrmwcxnjfw"
+          },
+          {
+            "/": "bafy2bzacecrn37ysicvhbfvpwjn4ssxl2sorrbo5yadurmsg4drfjmiq2bkzu"
+          },
+          {
+            "/": "bafy2bzaceaqqp5gqmf6k6px3qcli5v4pm33p43ecly4jjssoh5t36er2wtw7o"
+          },
+          {
+            "/": "bafy2bzacecx32uj6cdi232gxnkika2klsdxb43kmgrmkvczuvcgaeqxuft64y"
+          },
+          {
+            "/": "bafy2bzacebshmuniuatattub6kfxfsolyu575qy7dy32iuoryv75fm3haral2"
+          },
+          {
+            "/": "bafy2bzacea2muhvaedpor2lq4yvnkhbucamvibd56dlfam5gvocc4fm5odeye"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919758,
+        "PowerTable": {
+          "/": "bafy2bzacebugkf7swzihuwqkfwjyvm6rfd5gvlfhxeghsehsmat3kjca7svyw"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacedguljsabxj4rcm3k43bxywgv7xmxwheqjnyy4m32bus47xnfmznm"
+          },
+          {
+            "/": "bafy2bzaceb5bkczr2eq4xvxwrpusfdmegbhhnfyk32sqenw6rzvzgqntscvy6"
+          },
+          {
+            "/": "bafy2bzacedvivewvlv5kmjuuu3blg5ojp5hplawa3jgm7aepn32ggj6yyxkeg"
+          },
+          {
+            "/": "bafy2bzaceauttqfs44i3gzqbthlynflur77ovgb4mqeramjbv7lt36i2elwbm"
+          },
+          {
+            "/": "bafy2bzaceawvwrwe5e2gnfl42pkilangunsvyopn3f57z5somaqfaxpswetwy"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919759,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebq6qiyxo7j6sfm7iwfjdi7g3xzljt3m6t6tvory57vtljhy2ekya"
+          },
+          {
+            "/": "bafy2bzacedwpnrghbzxjyk45pxmt4rmi2dunw3juvqxsbwu5ivqwmncvry7kq"
+          },
+          {
+            "/": "bafy2bzacec5ppt7p36miwp3hdtmxoyk7juro765lqgzvwwq27cepibcf7rjvu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919760,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceavxuk7q4mffqabolnhdgc7ra7tywqb24qbnqaf5qgnylzp4d4jyy"
+          },
+          {
+            "/": "bafy2bzacedutla673ml4l65ihsd7hgozzn3gpvdcfh26crtuvoeadnzy2nz7k"
+          },
+          {
+            "/": "bafy2bzaceagdrz43wn5nw56apjebozrpnw5q7ptxt533ycovqjqqg2dcp3pim"
+          },
+          {
+            "/": "bafy2bzaceduqab5rrikqpzbcyigbdd7haspqyweiatqsr2xd2awxlbbkgc4y4"
+          },
+          {
+            "/": "bafy2bzaceaaa2ve237rb4efdv6e4zqr2d2e5avynfv6gtqp63yd2hfaxqrlwg"
+          },
+          {
+            "/": "bafy2bzacec6faalhepj7l4r6ko6hwqrahprerwyryitsw2y2lou5bf3tjgmt4"
+          },
+          {
+            "/": "bafy2bzacebre3wdz4otdtahhnq3v6jvzpvykrjcqki3iodizt4v2gpq3vintm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919761,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebiuxpevrbzhf6pyoob2hdatynkv3obsimx4l7u4n5w5inywazeje"
+          },
+          {
+            "/": "bafy2bzacecpoxifupxxxpnhm2zbp7n34bleuh66azwdcqwfvissqvpsr7xryg"
+          },
+          {
+            "/": "bafy2bzaceapas26fylpudhqd6ie2zgmtpuzfbxb6bfpfssjn7pgunm7ub3ayi"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919762,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceabuivzcp6fkruurubziopuxe2i4m3t5supblqe6fwqjvk5sg4tyw"
+          },
+          {
+            "/": "bafy2bzacebv27sm2x53rrhoy3uahrimback263dxb6t2cjzhtxk6g7w7oui5i"
+          },
+          {
+            "/": "bafy2bzaceb46drh37vtq3gch6ccyulxacs4monhhvcj3thtno3zugmnl6ax7i"
+          },
+          {
+            "/": "bafy2bzaceardoiglirmelphq7eg77vhwq7smey4ap6p5ksjyn4wdiufh6hkji"
+          },
+          {
+            "/": "bafy2bzaceayyyejgujlda5tj35uoafx5n64o6uxtr7osmda2sc4xvdkh76lba"
+          },
+          {
+            "/": "bafy2bzacea5aet2y7o2v5izt6solgob6m5ftokrtqwao74bmlpleqwe6mvfx6"
+          },
+          {
+            "/": "bafy2bzacedmykayzumxr5n7qtt7eieljer5h4gmcgxhkwcrysuhdnn6e7v32w"
+          },
+          {
+            "/": "bafy2bzacedbozh6bu74tjfx4zkep67kmoycbmk6deyn4455nmmvvvvrvfh3u2"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919763,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceaxe7hkj6vzkp6qpqxaoa6yhtoj6qhpx4zrc3kqtqbsko7akwi5ns"
+          },
+          {
+            "/": "bafy2bzacebtc5deuey3cytvrtr3vpbvaxmf76lvor6remwpknntgoavxgrekw"
+          },
+          {
+            "/": "bafy2bzacecfhq2ob3awfulfimpox5iuoe4zuz7zgkvu5u3gyuqw26isiehttg"
+          },
+          {
+            "/": "bafy2bzacecajqofxpto5nz4bc7jex6clbjdtmu5jae7pkazln3qxpuejbybik"
+          },
+          {
+            "/": "bafy2bzaceaq6q3demlbvxlr6be3mw3exove4bgfspfzasiigqcynnx5yfjjhs"
+          },
+          {
+            "/": "bafy2bzaceaiccjppwv5p5iftqz3yyg77b2h2ijuiorv3grgsw4b3lhofd2qfy"
+          },
+          {
+            "/": "bafy2bzaceaulja3bed2dz56o5p7fnv5das5bhtdpjz27sp6vnlr4rd3t5cmas"
+          },
+          {
+            "/": "bafy2bzacecka2df4lcwg375vmzbwzglngmfx6clbsz4wrgo6tx3pnjd225nwm"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919764,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebi2fz7q6trjhqyocqmpx254ajcl6ys4u3afvpm5awqqu3yvwtto4"
+          },
+          {
+            "/": "bafy2bzaceb6sph3lcsva4mt4pfw5miwxpiyxhb3sklnpankk4nplfjoexnapi"
+          },
+          {
+            "/": "bafy2bzacebxss7itxwudmnjnqh6xlyj5pk57jsvozbl2rnhx6rru7puemc6dk"
+          },
+          {
+            "/": "bafy2bzacea3apnehdtl2jmb3lfumaclvcswvrbs67ojzrycpmbqxaffn6yf56"
+          },
+          {
+            "/": "bafy2bzaceai7rbq3foqwypew6nke4c7nmziderd2v7f6oqnhgljylkxc3onfi"
+          },
+          {
+            "/": "bafy2bzacecbwigspwwkefxegj4x4g5ejl6yoafj64qhm4eokkcpyyu7lc5rba"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919765,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzaceditxmyln5ea6gtny2cvkwhzfmni4zqo6yhrd4w7kkwaww45vu66q"
+          },
+          {
+            "/": "bafy2bzaceb2zputrovuy4uxbhzyab5fqhhemwefr5fvrmsy2k5bogjesb4owu"
+          },
+          {
+            "/": "bafy2bzacebjb4oqgexz7bvbrpsotvbpeei52osrgnw56t3fgdagri673vt3oo"
+          },
+          {
+            "/": "bafy2bzacec6wmcjdyshtvsccqg4lobrtjl3cvgkw2uske7g664ncyuwpgtc62"
+          },
+          {
+            "/": "bafy2bzaceamzecjd5565qjxuome37qlpapoodisfi3o4yekywyn3pe4vqjjta"
+          },
+          {
+            "/": "bafy2bzacecv2fpfcoqw7pssfi5tinlcsjjsnskqkwovtr4gbhkj63la7thfxe"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919766,
+        "PowerTable": {
+          "/": "bafy2bzacebuwzh6k6553bkhitnazewa67pxl4hqiu4tmaisix6g2z2revm3nq"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebnn7fyutjwdgsntfxlm5zlm6mpzosr6szrtax5dcxqifwwg2gaq6"
+          },
+          {
+            "/": "bafy2bzacead6h654p2ywbpb3b5v3dsx3djiw4qsf2t7oq6rvpk77t2mgzg4wm"
+          },
+          {
+            "/": "bafy2bzacedjuy7o2ref4coqpuuizcnykkeepsinsr6cvtrqftlwo3jc7hzzno"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919767,
+        "PowerTable": {
+          "/": "bafy2bzacebtzwvrodb33mss4lzw6k2d62n4rvrt4iokltaorf7k7ilzrrajry"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecx5xknygkn4ll6y5lqpo4rv6clt5ltgqd63kqz6oedlgcjrs4gs4"
+          },
+          {
+            "/": "bafy2bzaceanhgb4ugnuvukftrrekiput6x3ttf5coynr4hbkxlvgu5asy4xmg"
+          },
+          {
+            "/": "bafy2bzacecimrh3jn5mprafasmn673lcato63xjpts77ydcj4rlhb5mrft66s"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919768,
+        "PowerTable": {
+          "/": "bafy2bzacebtzwvrodb33mss4lzw6k2d62n4rvrt4iokltaorf7k7ilzrrajry"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacectl3qv7lgxkdttwyfepr2pgf372go3cxu7iwvnkcwlrblern2ysw"
+          },
+          {
+            "/": "bafy2bzacebjumueskkzafmn4lvp6bnjmuxdtzf7jfzi7ghn423qyhaokrdori"
+          },
+          {
+            "/": "bafy2bzacec3wnpvzz337d6hy6gav6fdqgp7ozccp7fuhmaepimdajugg4v4mo"
+          },
+          {
+            "/": "bafy2bzaceb3zck3tv6cw6biizdwtagxvhwqgs3thamldefcku6i5jybf32fkg"
+          },
+          {
+            "/": "bafy2bzacedlkc75mufjfdxwrzgrrjowqlv2bpwrupt4zzolgjaktghdc3ztwu"
+          },
+          {
+            "/": "bafy2bzaceb7pjs33qfqdy4mtstzixdj5h6p4rscz4wxf4ahni7fjhkm6phhkq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919769,
+        "PowerTable": {
+          "/": "bafy2bzaceaakl2l5q7iydjlimkcxtafkicnaheienidgquinanauav747ueo2"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacebdzxv6loosmbnq6weej352tseb5p4kusss62y6pr7cy5sua7ezpm"
+          },
+          {
+            "/": "bafy2bzacecp6dapwxnsyedgpsnmkkn64dwexpq76os7jm73uappms3kw2paym"
+          },
+          {
+            "/": "bafy2bzacedqzbggredo5zoe2sot7rxxntikmrziztyogupfltupgwrw4kr5oo"
+          },
+          {
+            "/": "bafy2bzacebmjxspxnptpuelzdjnqm4loecoedluxfjqhjbzbgpntmhacueize"
+          },
+          {
+            "/": "bafy2bzacebi6ejou46cqtgnnhja3arxvoxshkthcaxc37fv72oyscknljwmfq"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919770,
+        "PowerTable": {
+          "/": "bafy2bzacecvu7m3ucplydb3c6wqip2r6kfrvzcqytdppbdeqafbcjugorxrwe"
+        }
+      },
+      {
+        "Key": [
+          {
+            "/": "bafy2bzacecoisoo6f4akknomrylu4l7aj6iunk6gmy2fcjlkos4om5qz2bano"
+          },
+          {
+            "/": "bafy2bzaceakroufxxihq2ge6tuimjjifsbcczu2x4widpraqa67rjq3uu3cua"
+          },
+          {
+            "/": "bafy2bzacedfpmobzpfknvnuxhzm2mu7kaxxxvzcr3ifyfvx5rk3amx2dx5huq"
+          },
+          {
+            "/": "bafy2bzaceasunbyxqzg4ly5zoixdocaz7obnnxhtwhq5vswxsimxpa245nncu"
+          }
+        ],
+        "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "Epoch": 4919771,
+        "PowerTable": {
+          "/": "bafy2bzacealkdcdt6jit6psauz56xirqbu5egjndcalruna4vnq6kq5rvb4qs"
+        }
+      }
+    ],
+    "SupplementalData": {
+      "Commitments": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      "PowerTable": {
+        "/": "bafy2bzaceb5yxdkkdomvwpfejeie5iagpx6ete6qnaaq7x4gt4w7isdi6xp2i"
+      }
+    },
+    "Signers": [
+      0,
+      5,
+      1,
+      9,
+      3,
+      1,
+      3,
+      3,
+      2,
+      2,
+      1,
+      1,
+      8,
+      1,
+      1,
+      3,
+      2,
+      5,
+      1,
+      5,
+      2,
+      2,
+      4,
+      2,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      1,
+      3,
+      1,
+      1,
+      4,
+      1,
+      2,
+      2,
+      1,
+      1,
+      3,
+      2,
+      3,
+      2,
+      2,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      1,
+      7,
+      1,
+      6,
+      3,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      2,
+      3,
+      1,
+      2,
+      2,
+      2,
+      3,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      2,
+      1,
+      3,
+      1,
+      2,
+      1,
+      2,
+      1,
+      4,
+      1,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1,
+      1,
+      5,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      13,
+      1,
+      1,
+      1,
+      1,
+      4,
+      5,
+      1,
+      4,
+      2,
+      1,
+      3,
+      17,
+      2,
+      3,
+      1,
+      5,
+      1,
+      12,
+      1,
+      2,
+      1,
+      5,
+      1,
+      8,
+      3,
+      5,
+      1,
+      8,
+      1,
+      4,
+      1,
+      4,
+      1,
+      1,
+      2,
+      7,
+      3,
+      4,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      3,
+      2,
+      1,
+      3,
+      1,
+      5,
+      1,
+      3,
+      1,
+      17,
+      3,
+      2,
+      2,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      7,
+      2,
+      6,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      9,
+      1,
+      7,
+      1,
+      2,
+      2,
+      6,
+      1,
+      10,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      8,
+      1,
+      1,
+      1,
+      4,
+      2,
+      2,
+      1,
+      2,
+      1,
+      3,
+      1,
+      1,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      4,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      4,
+      1,
+      2,
+      3,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      16,
+      1,
+      5,
+      1,
+      4,
+      1,
+      4,
+      1,
+      2,
+      1,
+      1,
+      1,
+      2,
+      1,
+      2,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      1,
+      1,
+      6,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      2,
+      3,
+      7,
+      2,
+      1,
+      6,
+      4,
+      8,
+      1,
+      7,
+      3,
+      1,
+      2,
+      2,
+      1,
+      1,
+      2,
+      3,
+      1,
+      1,
+      2,
+      5,
+      7,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      5,
+      1,
+      6,
+      1,
+      2,
+      1,
+      1,
+      1,
+      4,
+      1,
+      8,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      6,
+      1,
+      1,
+      6,
+      5,
+      1,
+      1,
+      1,
+      1,
+      5,
+      1,
+      3,
+      3,
+      2,
+      1,
+      1,
+      2,
+      5,
+      1,
+      6,
+      1,
+      5,
+      1,
+      3,
+      2,
+      6,
+      2,
+      3,
+      1,
+      4,
+      1,
+      3,
+      2,
+      1,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      1,
+      2,
+      7,
+      1,
+      2,
+      6,
+      2,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      2,
+      8,
+      2,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      1,
+      1,
+      4,
+      2,
+      4,
+      2,
+      2,
+      1,
+      1,
+      1,
+      3,
+      1,
+      1,
+      2,
+      2,
+      1,
+      8,
+      1,
+      3,
+      1,
+      2,
+      1,
+      4,
+      1,
+      1,
+      2,
+      1,
+      1,
+      5,
+      1,
+      3,
+      1,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      3,
+      2,
+      2,
+      1,
+      2,
+      1,
+      2,
+      5,
+      3,
+      2,
+      2,
+      6,
+      1,
+      1,
+      3,
+      1,
+      2,
+      3,
+      2,
+      2,
+      3,
+      1,
+      1,
+      4,
+      2,
+      2,
+      8,
+      4,
+      5,
+      1,
+      5,
+      1,
+      5,
+      1,
+      1,
+      1,
+      1,
+      1,
+      5,
+      2,
+      5,
+      1,
+      1,
+      1,
+      4,
+      1,
+      1,
+      1,
+      4,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      2,
+      3,
+      1,
+      4,
+      1,
+      1,
+      1,
+      1,
+      1,
+      12,
+      1,
+      1,
+      1,
+      1,
+      2,
+      9,
+      2,
+      2,
+      1,
+      9,
+      2,
+      1,
+      2,
+      1,
+      1,
+      3,
+      1,
+      5,
+      4,
+      5,
+      1,
+      8,
+      1,
+      1,
+      1,
+      6,
+      1,
+      7,
+      1,
+      1,
+      1,
+      7,
+      1,
+      1,
+      1,
+      4,
+      1,
+      2,
+      1,
+      2,
+      2,
+      2
+    ],
+    "Signature": "suMxS0y1zG+DbbE9b6gqDQTl1gYvIeHhLEpqubebFV9XFiFmAnrOmrZ/QgvJYGjBEdMnElapTLCPl6JIPhqIKIbD86RAGZTW6z7wh0rz0Y+LY4IieXlhmveY8Gj6SWdM",
+    "PowerTableDelta": [
+      {
+        "ParticipantID": 101020,
+        "PowerDelta": "16758962388992",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 522948,
+        "PowerDelta": "687194767360",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 1052556,
+        "PowerDelta": "242133076279296",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 1708981,
+        "PowerDelta": "343597383680",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 1927220,
+        "PowerDelta": "-80607946211328",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 2825666,
+        "PowerDelta": "-9620726743040",
+        "SigningKey": null
+      },
+      {
+        "ParticipantID": 2826888,
+        "PowerDelta": "-4123168604160",
+        "SigningKey": null
+      }
+    ]
+  }
+]

--- a/rpc/src/types.rs
+++ b/rpc/src/types.rs
@@ -5,7 +5,7 @@ use filecoin_f3_gpbft::ActorId;
 use num_bigint::BigInt;
 use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FinalityCertificate {
     #[serde(rename = "GPBFTInstance")]
     pub instance: u64,
@@ -26,7 +26,7 @@ pub struct FinalityCertificate {
     pub power_table_delta: Vec<PowerTableDelta>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ECTipSet {
     #[serde(rename = "Key")]
     pub key: Vec<CidRef>,
@@ -41,7 +41,7 @@ pub struct ECTipSet {
     pub power_table: CidRef,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SupplementalData {
     #[serde(rename = "Commitments")]
     pub commitments: String,
@@ -50,7 +50,7 @@ pub struct SupplementalData {
     pub power_table: CidRef,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PowerTableDelta {
     #[serde(rename = "ParticipantID")]
     pub participant_id: ActorId,


### PR DESCRIPTION
  # Implement BDN signature aggregation scheme

  Closes https://github.com/ChainSafe/rust-f3/issues/29

  This PR implements the BDN aggregation scheme for BLS signatures, fixing certificate verification failures in the F3 lightclient.

  Due to the lack of Rust implementation for Blake2X XOF (specifically the 32-bit Blake2Xs variant), this PR uses the
  pending PR https://github.com/RustCrypto/hashes/pull/704

  ## Changes

  * Implemented BDN coefficient computation using Blake2Xs XOF
  * Added coefficient weighting for both signatures and public keys aggregation
  * Updated `Verifier::verify_aggregate()` API to accept full power table and signer indices (BDN
  requires all keys for correct coefficient computation)
  * Removed temporary workaround that was silencing verification errors

  ## Testing

  Verified correctness using the `certificates_validation` example:
```
  cargo run --example certificates_validation -- calibrationnet
  cargo run --example certificates_validation -- filecoin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now accepts a power table plus signer indices and uses precomputed per-key data for aggregation.
  * Added caching to reuse precomputed aggregation data.

* **Bug Fixes**
  * Improved validation with new error cases for empty signers, invalid scalars, and out-of-range signer indices.

* **Tests**
  * Added an end-to-end test for aggregate signature verification using power table and indices.

* **Chores**
  * Updated cryptography and parallelism dependencies and augmented public/static data entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->