### PR TITLE
chore: bump rust toolchain and deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: |
-            sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
+            sudo apt-get install -y build-essential # required dep for cargo-spellcheck
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14"
+          version: "18"
       - name: Install Lint tools
         run: make install-lint-tools-ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
         env:
           RUSTC_WRAPPER:
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: lcov.info
           path: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test:
     name: build-and-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     steps:
       - uses: actions/checkout@v5
       - name: Setup sccache
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     name: All lint checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     steps:
       - uses: actions/checkout@v5
       - name: Setup sccache
@@ -55,7 +55,7 @@ jobs:
 
   dependencies-check:
     name: Check cargo dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby
@@ -67,7 +67,7 @@ jobs:
           gem install toml-rb --no-document
           ruby scripts/linters/find_unused_deps.rb
   codedov:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     steps:
       - uses: actions/checkout@v5
       - uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           gem install toml-rb --no-document
           ruby scripts/linters/find_unused_deps.rb
-  codedov:
+  codecov:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
         timeout-minutes: 5
         continue-on-error: true
+      - name: Apt Dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: |
+            sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,9 @@ jobs:
           name: lcov.info
           path: lcov.info
           if-no-files-found: error
-      - name: Upload to codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -f lcov.info -Z
+      - name: Upload CodeCov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test:
     name: build-and-test
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Setup sccache
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     name: All lint checks
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Setup sccache
@@ -55,7 +55,7 @@ jobs:
 
   dependencies-check:
     name: Check cargo dependencies
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby
@@ -67,7 +67,7 @@ jobs:
           gem install toml-rb --no-document
           ruby scripts/linters/find_unused_deps.rb
   codedov:
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: build-and-test
     runs-on: ubuntu-latest-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
         timeout-minutes: 5
@@ -37,7 +37,7 @@ jobs:
     name: All lint checks
     runs-on: ubuntu-latest-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
         timeout-minutes: 5
@@ -57,7 +57,7 @@ jobs:
     name: Check cargo dependencies
     runs-on: ubuntu-latest-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -69,7 +69,7 @@ jobs:
   codedov:
     runs-on: ubuntu-latest-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -36,7 +36,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,7 +9,7 @@ jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     permissions:
       contents: write
     steps:
@@ -28,7 +28,7 @@ jobs:
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,7 +9,7 @@ jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:
@@ -28,7 +28,7 @@ jobs:
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
       pull-requests: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,25 +12,26 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
-base32 = "0.5.1"
+base32 = "0.5"
 base64 = "0.22"
 bls-signatures = { version = "0.15" }
 bls12_381 = "0.8"
-cid = { version = "0.10.1", features = ["std"] }
-fvm_ipld_bitfield = "0.7.1"
+cid = { version = "0.11", features = ["std"] }
+fvm_ipld_bitfield = "0.7"
 fvm_ipld_encoding = "0.5"
-hashlink = "0.10.0"
+hashlink = "0.11"
 hex = "0.4"
 jsonrpsee = { version = "0.26", features = ["ws-client", "http-client"] }
-keccak-hash = "0.11"
-num-bigint = { version = "0.4.6", features = ["serde"] }
-num-traits = "0.2.19"
+keccak-hash = "0.12"
+multihash-codetable = { version = "0.1" }
+num-bigint = { version = "0.4", features = ["serde"] }
+num-traits = "0.2"
 parking_lot = "0.12"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
-serde_cbor = "0.11.2"
+serde_cbor = { package = "serde_cbor_2", version = "0.13" }
 serde_json = { version = "1", features = ["raw_value"] }
-sha3 = "0.10.8"
+sha3 = "0.10"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 thiserror = "2"

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,20 @@ install-lint-tools:
 	cargo install --locked cargo-deny
 	cargo install --locked cargo-spellcheck
 
-install-lint-tools-ci:
-	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-	tar xzf cargo-binstall-x86_64-unknown-linux-musl.tgz
+# Denotes the architecture of the machine. This is required for direct binary downloads.
+# Note that some repositories might use different names for the same architecture.
+CPU_ARCH := $(shell \
+  ARCH=$$(uname -m); \
+  if [ "$$ARCH" = "arm64" ]; then \
+    ARCH="aarch64"; \
+  fi; \
+  echo "$$ARCH" \
+)
+
+install-cargo-binstall:
+	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$(CPU_ARCH)-unknown-linux-musl.tgz
+	tar xzf cargo-binstall-$(CPU_ARCH)-unknown-linux-musl.tgz
 	cp cargo-binstall ~/.cargo/bin/cargo-binstall
 
+install-lint-tools-ci: install-cargo-binstall
 	cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-deny

--- a/gpbft/Cargo.toml
+++ b/gpbft/Cargo.toml
@@ -18,6 +18,7 @@ filecoin-f3-merkle = { path = "../merkle", version = "0.1.0" }
 fvm_ipld_bitfield = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 keccak-hash = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/gpbft/Cargo.toml
+++ b/gpbft/Cargo.toml
@@ -32,7 +32,8 @@ base64 = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom_0_3 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 
 [features]
 test-utils = []

--- a/gpbft/src/chain.rs
+++ b/gpbft/src/chain.rs
@@ -3,9 +3,8 @@
 
 use crate::GPBFTError;
 pub use cid::Cid;
-use cid::multihash::Code::Blake2b256;
-use cid::multihash::MultihashDigest;
 use fvm_ipld_encoding::DAG_CBOR;
+use multihash_codetable::{Code::Blake2b256, MultihashDigest as _};
 use std::fmt::Display;
 use std::{cmp, fmt};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.92.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
- bump rust toolchain
- bump deps
- use arm CI runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI runners switched to ubuntu-24.04-arm and GitHub Actions updated to newer versions.
  * Lint job hardened with apt dependency install (retry) and LLVM/Clang updated to v18.
  * Coverage and artifact upload steps modernized; Codecov action added.
  * Build/install tooling made architecture-aware for cross-arch installs.
  * Rust toolchain bumped; workspace dependencies updated and a new multihash package added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->